### PR TITLE
Add compatibility with Python2.7

### DIFF
--- a/snapcast/control.py
+++ b/snapcast/control.py
@@ -16,7 +16,7 @@ CONTROL_PORT = 1705
 _NEWLINE = b'\r\n'
 _ENCODING = 'utf-8'
 _READ_TIMEOUT = 0.5
-_RESP_TIMEOUT = 2.0  # In python2.7 response time is longer
+_RESP_TIMEOUT = 4.0  # In python2.7 response time is longer
 
 SERVER_GETSTATUS = 'Server.GetStatus'
 SERVER_DELETECLIENT = 'Server.DeleteClient'
@@ -38,7 +38,7 @@ _METHODS = [SERVER_GETSTATUS, SERVER_DELETECLIENT, CLIENT_SETNAME,
             CLIENT_SETVOLUME]
 
 
-class Snapclient:
+class Snapclient(object):
     """ Represents a snapclient. """
     def __init__(self, server, data):
         self._server = server
@@ -150,7 +150,7 @@ class Snapclient:
                                                self._mac)
 
 
-class Snapserver:
+class Snapserver(object):
     """ Represents a snapserver. """
     def __init__(self, host, port=CONTROL_PORT):
         self._conn = telnetlib.Telnet(host, port)
@@ -354,7 +354,7 @@ class Snapserver:
         return 'Snapserver {} ({})'.format(self.version, self._host)
 
 
-class Snapstream:
+class Snapstream(object):
     """ Represents a snapcast stream. """
     def __init__(self, data):
         self.update(data)

--- a/snapcast/control.py
+++ b/snapcast/control.py
@@ -16,7 +16,7 @@ CONTROL_PORT = 1705
 _NEWLINE = b'\r\n'
 _ENCODING = 'utf-8'
 _READ_TIMEOUT = 0.5
-_RESP_TIMEOUT = 1.0
+_RESP_TIMEOUT = 2.0  # In python2.7 response time is longer
 
 SERVER_GETSTATUS = 'Server.GetStatus'
 SERVER_DELETECLIENT = 'Server.DeleteClient'
@@ -152,14 +152,15 @@ class Snapclient:
 
 class Snapserver:
     """ Represents a snapserver. """
-    def __init__(self, host, port):
+    def __init__(self, host, port=CONTROL_PORT):
         self._conn = telnetlib.Telnet(host, port)
         self._host = host
         self._clients = {}
         self._streams = {}
         self._buffer = {}
         self._queue = queue.Queue()
-        tcp = threading.Thread(target=self._read, daemon=True)
+        tcp = threading.Thread(target=self._read)
+        tcp.setDaemon(True) #python2.7
         tcp.start()
         self.synchronize()
 
@@ -379,4 +380,4 @@ class Snapstream:
 
     def __repr__(self):
         """ String representation. """
-        return self.name
+        return 'Snapstream ({})'.format(self.name)


### PR DESCRIPTION
I wanted to use your library in an integrated client I'm building to control both mopidy and snapcast, but my code is using python2.7. So I made some changes to make it compatible with both versions of python:
- Thread uses `setDaemon()` method  instead of `daemon` arg
- Change RESP_TIMEOUT up to 4 seconds since responses seems to be quite slower
- Classes inherit from `object` to have new-style class capabilities

I have tested it using python2.7 and python3.4, and `snapserver` version 0.10.0

If you'd like to keep your code pure Python3 I totally get it. You could use maybe two branches, or else I will try to keep my fork synced with the new changes to master.