### PR TITLE
Pass the client/group object to the callback

### DIFF
--- a/snapcast/control/client.py
+++ b/snapcast/control/client.py
@@ -124,7 +124,7 @@ class Snapclient(object):
     def callback(self):
         """Run callback."""
         if self._callback_func and callable(self._callback_func):
-            self._callback_func()
+            self._callback_func(self)
 
     def set_callback(self, func):
         """Set callback function."""

--- a/snapcast/control/group.py
+++ b/snapcast/control/group.py
@@ -131,7 +131,7 @@ class Snapgroup(object):
     def callback(self):
         """Run callback."""
         if self._callback_func and callable(self._callback_func):
-            self._callback_func()
+            self._callback_func(self)
 
     def set_callback(self, func):
         """Set callback."""

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -84,4 +84,4 @@ class TestSnapclient(unittest.TestCase):
         cb = MagicMock()
         self.client.set_callback(cb)
         self.client.update_connected(False)
-        self.assertTrue(cb.called)
+        cb.assert_called_with(self.client)

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -80,4 +80,4 @@ class TestSnapgroup(unittest.TestCase):
         cb = MagicMock()
         self.group.set_callback(cb)
         self.group.update_mute({'mute': True})
-        self.assertTrue(cb.called)
+        cb.assert_called_with(self.group)


### PR DESCRIPTION
This is a small change, but seems useful to me. Right now a callback doesn't know which object it is being called on; so, for example, if I have one `client_updated()` callback that I attach to every client, I have no way of knowing which client has been updated when my callback runs.