### PR TITLE
Adding a "new client" callback to the server object

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -205,6 +205,8 @@ class TestSnapserver(unittest.TestCase):
         self.assertEqual(self.server.group('test').stream, 'other')
 
     def test_on_client_connect(self):
+        cb = mock.MagicMock()
+        self.server.set_new_client_callback(cb)
         data = {
             'id': 'new',
             'client': {
@@ -220,6 +222,7 @@ class TestSnapserver(unittest.TestCase):
         }
         self.server._on_client_connect(data)
         self.assertEqual(self.server.client('new').connected, True)
+        cb.assert_called_with(self.server.client('new'))
 
     def test_on_client_disconnect(self):
         data = {


### PR DESCRIPTION
This adds a new callback on the server object, to notify when a new (not seen before) client connects.

I wasn't sure how you'd prefer this kind of callback to be set up; I imagine it either has to be new-client specific, or a generic "server has been updated". In the latter case, it would be triggered on any change, not just a new client connection. That seems a bit less useful, at least in my specific use-case.

Please let me know if you'd prefer it done a different way.