### PR TITLE
New server callbacks: connect, disconnect, new client

### DIFF
--- a/snapcast/control/protocol.py
+++ b/snapcast/control/protocol.py
@@ -4,6 +4,8 @@ import asyncio
 import json
 import random
 
+SERVER_ONCONNECT = 'Server.OnConnect'
+SERVER_ONDISCONNECT = 'Server.OnDisconnect'
 
 def jsonrpc_request(method, identifier, params=None):
     """Produce a JSONRPC request."""
@@ -27,6 +29,11 @@ class SnapcastProtocol(asyncio.Protocol):
     def connection_made(self, transport):
         """When a connection is made."""
         self._transport = transport
+        self._callbacks.get(SERVER_ONCONNECT)()
+
+    def connection_lost(self, exception):
+        """When a connection is lost."""
+        self._callbacks.get(SERVER_ONDISCONNECT)(exception)
 
     def data_received(self, data):
         """Handle received data."""

--- a/snapcast/control/protocol.py
+++ b/snapcast/control/protocol.py
@@ -7,6 +7,7 @@ import random
 SERVER_ONCONNECT = 'Server.OnConnect'
 SERVER_ONDISCONNECT = 'Server.OnDisconnect'
 
+
 def jsonrpc_request(method, identifier, params=None):
     """Produce a JSONRPC request."""
     return '{}\r\n'.format(json.dumps({

--- a/snapcast/control/protocol.py
+++ b/snapcast/control/protocol.py
@@ -4,7 +4,6 @@ import asyncio
 import json
 import random
 
-SERVER_ONCONNECT = 'Server.OnConnect'
 SERVER_ONDISCONNECT = 'Server.OnDisconnect'
 
 
@@ -30,7 +29,6 @@ class SnapcastProtocol(asyncio.Protocol):
     def connection_made(self, transport):
         """When a connection is made."""
         self._transport = transport
-        self._callbacks.get(SERVER_ONCONNECT)()
 
     def connection_lost(self, exception):
         """When a connection is lost."""

--- a/snapcast/control/server.py
+++ b/snapcast/control/server.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import logging
-from snapcast.control.protocol import SnapcastProtocol, SERVER_ONCONNECT, SERVER_ONDISCONNECT
+from snapcast.control.protocol import SnapcastProtocol, SERVER_ONDISCONNECT
 from snapcast.control.client import Snapclient
 from snapcast.control.group import Snapgroup
 from snapcast.control.stream import Snapstream
@@ -69,7 +69,6 @@ class Snapserver(object):
             GROUP_ONMUTE: self._on_group_mute,
             GROUP_ONSTREAMCHANGED: self._on_group_stream_changed,
             STREAM_ONUPDATE: self._on_stream_update,
-            SERVER_ONCONNECT: self._on_server_connect,
             SERVER_ONDISCONNECT: self._on_server_disconnect,
             SERVER_ONUPDATE: self._on_server_update
         }
@@ -84,6 +83,7 @@ class Snapserver(object):
         _LOGGER.info('connected to snapserver on %s:%s', self._host, self._port)
         status = yield from self.status()
         self.synchronize(status)
+        self._on_server_connect()
 
     @asyncio.coroutine
     def _transact(self, method, params=None):

--- a/snapcast/control/server.py
+++ b/snapcast/control/server.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import logging
-from snapcast.control.protocol import SnapcastProtocol
+from snapcast.control.protocol import SnapcastProtocol, SERVER_ONCONNECT, SERVER_ONDISCONNECT
 from snapcast.control.client import Snapclient
 from snapcast.control.group import Snapgroup
 from snapcast.control.stream import Snapstream
@@ -15,8 +15,6 @@ CONTROL_PORT = 1705
 SERVER_GETSTATUS = 'Server.GetStatus'
 SERVER_GETRPCVERSION = 'Server.GetRPCVersion'
 SERVER_DELETECLIENT = 'Server.DeleteClient'
-SERVER_ONCONNECT = 'Server.OnConnect'
-SERVER_ONDISCONNECT = 'Server.OnDisconnect'
 SERVER_ONUPDATE = 'Server.OnUpdate'
 
 CLIENT_GETSTATUS = 'Client.GetStatus'

--- a/snapcast/control/server.py
+++ b/snapcast/control/server.py
@@ -46,6 +46,7 @@ _METHODS = [SERVER_GETSTATUS, SERVER_GETRPCVERSION, SERVER_DELETECLIENT,
             GROUP_GETSTATUS, GROUP_SETMUTE, GROUP_SETSTREAM, GROUP_SETCLIENTS]
 
 
+# pylint: disable=too-many-public-methods
 class Snapserver(object):
     """Represents a snapserver."""
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -205,6 +205,8 @@ class TestSnapserver(unittest.TestCase):
         self.assertEqual(self.server.group('test').stream, 'other')
 
     def test_on_client_connect(self):
+        cb = mock.MagicMock()
+        self.server.set_new_client_callback(cb)
         data = {
             'id': 'new',
             'client': {
@@ -220,6 +222,7 @@ class TestSnapserver(unittest.TestCase):
         }
         self.server._on_client_connect(data)
         self.assertEqual(self.server.client('new').connected, True)
+        cb.assert_called_with(self.server.client('new'))
 
     def test_on_client_disconnect(self):
         data = {

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -186,7 +186,7 @@ class TestSnapserver(unittest.TestCase):
         cb = mock.MagicMock()
         self.server.set_on_connect_callback(cb)
         self.server._on_server_connect()
-        cb.assert_called()
+        cb.assert_called_with()
 
     def test_on_server_disconnect(self):
         cb = mock.MagicMock()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -182,6 +182,19 @@ class TestSnapserver(unittest.TestCase):
         self.server.synchronize(status)
         self.assertEqual(self.server.version, '0.12')
 
+    def test_on_server_connect(self):
+        cb = mock.MagicMock()
+        self.server.set_on_connect_callback(cb)
+        self.server._on_server_connect()
+        cb.assert_called()
+
+    def test_on_server_disconnect(self):
+        cb = mock.MagicMock()
+        self.server.set_on_disconnect_callback(cb)
+        e = Exception()
+        self.server._on_server_disconnect(e)
+        cb.assert_called_with(e)
+
     def test_on_server_update(self):
         status = copy.deepcopy(return_values.get('Server.GetStatus'))
         status['server']['version'] = '0.12'


### PR DESCRIPTION
This is my first attempt at #7, providing callbacks for snapserver connection and disconnection.

Some things to note:
* I'm not a huge fan of declaring the `SERVER_ON(DIS)CONNECT` constants in both `server.py` and `protocol.py`- please let me know if this can be improved somehow.
* This includes my proposed solution to #5 (new client callback) as well. Please let me know if you'd rather I remove that change from this PR.

Thanks!