### PR TITLE
Add reconnect support to snapcast server control.

### DIFF
--- a/snapcast/control/__init__.py
+++ b/snapcast/control/__init__.py
@@ -5,8 +5,8 @@ from snapcast.control.server import Snapserver, CONTROL_PORT
 
 
 @asyncio.coroutine
-def create_server(loop, host, port=CONTROL_PORT):
+def create_server(loop, host, port=CONTROL_PORT, reconnect=False):
     """Server factory."""
-    server = Snapserver(loop, host, port)
+    server = Snapserver(loop, host, port, reconnect)
     yield from server.start()
     return server


### PR DESCRIPTION
This adds a new parameter "reconnect" to the Snapserver instance that
can be set to true, to make the instance trying to reconnect to the
server if the connection was lost.

The reconnect is tried immediately. If not successful, it will retry
every 5 seconds.

This is useful when you use the Snapserver implementation in some
long-running application (like HomeAssistant) and want to be able to
use the snapcast integration after a reboot/restart of the snapcast
server without a need to start the using application.

(see https://github.com/home-assistant/home-assistant/issues/10264)