### PR TITLE
Decorate async functions as coroutine.

### DIFF
--- a/snapcast/control/client.py
+++ b/snapcast/control/client.py
@@ -1,5 +1,5 @@
 """Snapcast client."""
-
+import asyncio
 import logging
 
 
@@ -52,6 +52,7 @@ class Snapclient(object):
         """Name."""
         return self._client.get('config').get('name')
 
+    @asyncio.coroutine
     def set_name(self, name):
         """Set a client name."""
         if not name:
@@ -64,6 +65,7 @@ class Snapclient(object):
         """Latency."""
         return self._client.get('config').get('latency')
 
+    @asyncio.coroutine
     def set_latency(self, latency):
         """Set client latency."""
         self._client['config']['latency'] = latency
@@ -74,6 +76,7 @@ class Snapclient(object):
         """Muted or not."""
         return self._client.get('config').get('volume').get('muted')
 
+    @asyncio.coroutine
     def set_muted(self, status):
         """Set client mute status."""
         new_volume = self._client['config']['volume']
@@ -87,6 +90,7 @@ class Snapclient(object):
         """Volume percent."""
         return self._client.get('config').get('volume').get('percent')
 
+    @asyncio.coroutine
     def set_volume(self, percent, update_group=True):
         """Set client volume percent."""
         if percent not in range(0, 101):
@@ -134,6 +138,7 @@ class Snapclient(object):
         }
         _LOGGER.info('took snapshot of current state of %s', self.friendly_name)
 
+    @asyncio.coroutine
     def restore(self):
         """Restore snapshotted state."""
         if not self._snapshot:

--- a/snapcast/control/group.py
+++ b/snapcast/control/group.py
@@ -1,5 +1,5 @@
 """Snapcast group."""
-
+import asyncio
 import logging
 
 
@@ -36,6 +36,7 @@ class Snapgroup(object):
         """Get stream identifier."""
         return self._group.get('stream_id')
 
+    @asyncio.coroutine
     def set_stream(self, stream_id):
         """Set group stream."""
         self._group['stream_id'] = stream_id
@@ -52,6 +53,7 @@ class Snapgroup(object):
         """Get mute status."""
         return self._group.get('muted')
 
+    @asyncio.coroutine
     def set_muted(self, status):
         """Set group mute status."""
         self._group['muted'] = status
@@ -66,6 +68,7 @@ class Snapgroup(object):
             volume_sum += self._server.client(client.get('id')).volume
         return int(volume_sum / len(self._group.get('clients')))
 
+    @asyncio.coroutine
     def set_volume(self, volume):
         """Set volume."""
         for data in self._group.get('clients'):
@@ -89,6 +92,7 @@ class Snapgroup(object):
         """Get client identifiers."""
         return [client.get('id') for client in self._group.get('clients')]
 
+    @asyncio.coroutine
     def add_client(self, client_identifier):
         """Add a client."""
         if client_identifier in self.clients:
@@ -101,6 +105,7 @@ class Snapgroup(object):
         self._server.client(client_identifier).callback()
         self.callback()
 
+    @asyncio.coroutine
     def remove_client(self, client_identifier):
         """Remove a client."""
         new_clients = self.clients
@@ -135,6 +140,7 @@ class Snapgroup(object):
         }
         _LOGGER.info('took snapshot of current state of %s', self.friendly_name)
 
+    @asyncio.coroutine
     def restore(self):
         """Restore snapshotted state."""
         if not self._snapshot:

--- a/snapcast/control/server.py
+++ b/snapcast/control/server.py
@@ -80,6 +80,7 @@ class Snapserver(object):
         self._on_disconnect_callback_func = None
         self._new_client_callback_func = None
 
+    @asyncio.coroutine
     def start(self):
         """Initiate server connection."""
         yield from self._do_connect()
@@ -117,6 +118,7 @@ class Snapserver(object):
         """Version."""
         return self._version
 
+    @asyncio.coroutine
     def status(self):
         """System status."""
         result = yield from self._transact(SERVER_GETSTATUS)
@@ -126,6 +128,7 @@ class Snapserver(object):
         """RPC version."""
         return self._transact(SERVER_GETRPCVERSION)
 
+    @asyncio.coroutine
     def delete_client(self, identifier):
         """Delete client."""
         params = {'id': identifier}
@@ -207,6 +210,7 @@ class Snapserver(object):
                 self._clients[client.get('id')] = Snapclient(self, client)
                 _LOGGER.debug('client found: %s', self._clients[client.get('id')])
 
+    @asyncio.coroutine
     def _request(self, method, identifier, key=None, value=None):
         """Perform request with identifier."""
         params = {'id': identifier}


### PR DESCRIPTION
Not all async functions were properly decorated as coroutine. This means that it's not compatible with the async/await syntax in Python 3.5+