### PR TITLE
Allow to invoke a callback when Server.OnUpdate is received

### DIFF
--- a/snapcast/control/server.py
+++ b/snapcast/control/server.py
@@ -76,6 +76,7 @@ class Snapserver(object):
             SERVER_ONDISCONNECT: self._on_server_disconnect,
             SERVER_ONUPDATE: self._on_server_update
         }
+        self._on_update_callback_func = None
         self._on_connect_callback_func = None
         self._on_disconnect_callback_func = None
         self._new_client_callback_func = None
@@ -235,6 +236,8 @@ class Snapserver(object):
     def _on_server_update(self, data):
         """Handle server update."""
         self.synchronize(data)
+        if self._on_update_callback_func and callable(self._on_update_callback_func):
+            self._on_update_callback_func()
 
     def _on_group_mute(self, data):
         """Handle group mute."""
@@ -281,6 +284,10 @@ class Snapserver(object):
         for group in self._groups.values():
             if group.stream == data.get('id'):
                 group.callback()
+
+    def set_on_update_callback(self, func):
+        """Set on update callback function."""
+        self._on_update_callback_func = func
 
     def set_on_connect_callback(self, func):
         """Set on connection callback function."""

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -196,10 +196,13 @@ class TestSnapserver(unittest.TestCase):
         cb.assert_called_with(e)
 
     def test_on_server_update(self):
+        cb = mock.MagicMock()
+        self.server.set_on_update_callback(cb)
         status = copy.deepcopy(return_values.get('Server.GetStatus'))
         status['server']['version'] = '0.12'
         self.server._on_server_update(status)
         self.assertEqual(self.server.version, '0.12')
+        cb.assert_called_with()
 
     def test_on_group_mute(self):
         data = {


### PR DESCRIPTION
There are several actions, such as reassigning clients to different groups, that make the snapcast server send a Server.OnUpdate event. This makes python-snapcast to call server.synchronize(), which cleans up everything (streams, groups, clients), which means you lose any callback you had configured for them.

I've added an optional callback for this server update event, so that your client can associate again the callbacks for groups and clients once their objects have been reconstructed.

N.B: I've not been able to run the test environment, so I couldn't ensure the tests keep passing, so please review them before merging