### PR TITLE
Add callback function when steam changes state

### DIFF
--- a/snapcast/control/server.py
+++ b/snapcast/control/server.py
@@ -298,6 +298,7 @@ class Snapserver(object):
         """Handle stream update."""
         self._streams[data.get('id')].update(data.get('stream'))
         _LOGGER.info('stream %s updated', self._streams[data.get('id')].friendly_name)
+        self._streams[data.get("id")].callback()
         for group in self._groups.values():
             if group.stream == data.get('id'):
                 group.callback()

--- a/snapcast/control/stream.py
+++ b/snapcast/control/stream.py
@@ -7,6 +7,7 @@ class Snapstream(object):
     def __init__(self, data):
         """Initialize."""
         self.update(data)
+        self._callback_func = None
 
     @property
     def identifier(self):
@@ -44,3 +45,12 @@ class Snapstream(object):
     def __repr__(self):
         """String representation."""
         return 'Snapstream ({})'.format(self.name)
+
+    def callback(self):
+        """Run callback."""
+        if self._callback_func and callable(self._callback_func):
+            self._callback_func(self)
+
+    def set_callback(self, func):
+        """Set callback."""
+        self._callback_func = func


### PR DESCRIPTION
Added callback function for a stream. This way, the state of a stream can be updated when a callback occurs from snapcast.
this change is needed to create stream sensors in Home assistant.