### PR TITLE
No-op when setting a group to the same volume

### DIFF
--- a/snapcast/control/group.py
+++ b/snapcast/control/group.py
@@ -72,6 +72,9 @@ class Snapgroup(object):
     def set_volume(self, volume):
         """Set volume."""
         current_volume = self.volume
+        if volume == current_volume:
+            _LOGGER.info('left volume at %s on group %s', volume, self.friendly_name)
+            return
         delta = volume - current_volume
         if delta < 0:
             ratio = (current_volume - volume) / current_volume

--- a/snapcast/control/group.py
+++ b/snapcast/control/group.py
@@ -71,6 +71,8 @@ class Snapgroup(object):
     @asyncio.coroutine
     def set_volume(self, volume):
         """Set volume."""
+        if volume not in range(0, 101):
+            raise ValueError('Volume out of range')
         current_volume = self.volume
         if volume == current_volume:
             _LOGGER.info('left volume at %s on group %s', volume, self.friendly_name)


### PR DESCRIPTION
This prevents division by 0 when setting a group to 100 when it is already at 100