### PR TITLE
Group.SetName and _version_check

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ setup(
     packages=['snapcast', 'snapcast.control', 'snapcast.client'],
     install_requires=[
         'construct>=2.5.2',
+        'packaging',
     ],
     classifiers=[
         'License :: OSI Approved :: MIT License',

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup
+from setuptools import setup
 
 setup(
     name='snapcast',

--- a/snapcast/control/group.py
+++ b/snapcast/control/group.py
@@ -31,6 +31,14 @@ class Snapgroup(object):
         """Get group name."""
         return self._group.get('name')
 
+    @asyncio.coroutine
+    def set_name(self, name):
+        """Set a group name."""
+        if not name:
+            name = ''
+        self._group['name'] = name
+        yield from self._server.group_name(self.identifier, name)
+
     @property
     def stream(self):
         """Get stream identifier."""

--- a/snapcast/control/server.py
+++ b/snapcast/control/server.py
@@ -32,6 +32,7 @@ GROUP_GETSTATUS = 'Group.GetStatus'
 GROUP_SETMUTE = 'Group.SetMute'
 GROUP_SETSTREAM = 'Group.SetStream'
 GROUP_SETCLIENTS = 'Group.SetClients'
+GROUP_SETNAME = 'Group.SetName'
 GROUP_ONMUTE = 'Group.OnMute'
 GROUP_ONSTREAMCHANGED = 'Group.OnStreamChanged'
 
@@ -48,7 +49,7 @@ _METHODS = [SERVER_GETSTATUS, SERVER_GETRPCVERSION, SERVER_DELETECLIENT,
             SERVER_DELETECLIENT, CLIENT_GETSTATUS, CLIENT_SETNAME,
             CLIENT_SETLATENCY, CLIENT_SETSTREAM, CLIENT_SETVOLUME,
             GROUP_GETSTATUS, GROUP_SETMUTE, GROUP_SETSTREAM, GROUP_SETCLIENTS,
-            STREAM_SETMETA]
+            GROUP_SETNAME, STREAM_SETMETA]
 
 
 # pylint: disable=too-many-public-methods
@@ -171,6 +172,10 @@ class Snapserver(object):
     def group_clients(self, identifier, clients):
         """Set group clients."""
         return self._request(GROUP_SETCLIENTS, identifier, 'clients', clients)
+
+    def group_name(self, identifier, name):
+        """Set group name."""
+        return self._request(GROUP_SETNAME, identifier, 'name', name)
 
     def stream_setmeta(self, identifier, meta):
         """Set stream metadata."""

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -56,6 +56,10 @@ class TestSnapgroup(unittest.TestCase):
         async_run(self.group.set_stream('new stream'))
         self.assertEqual(self.group.stream, 'new stream')
 
+    def test_set_name(self):
+        async_run(self.group.set_name('test'))
+        self.assertEqual(self.group.name, 'test')
+
     def test_add_client(self):
         self.group.add_client('c')
         # TODO: add assert

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -29,7 +29,6 @@ class TestSnapgroup(unittest.TestCase):
         server.client = MagicMock(return_value=client)
         self.group = Snapgroup(server, data)
 
-
     def test_init(self):
         self.assertEqual(self.group.identifier, 'test')
         self.assertEqual(self.group.name, '')

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -8,10 +8,25 @@ from snapcast.control.server import Snapserver
 from snapcast.control import create_server
 
 
+SERVER_STATUS = {
+    'host': {
+        'arch': 'x86_64',
+        'ip': '',
+        'mac': '',
+        'name': 'T400',
+        'os': 'Linux Mint 17.3 Rosa'
+    },
+    'snapserver': {
+        'controlProtocolVersion': 1,
+        'name': 'Snapserver',
+        'protocolVersion': 1,
+        'version': '0.12.0'
+    }
+}
+
 return_values = {
     'Server.GetStatus': {
         'server': {
-            'version': 0.11,
             'groups': [
                 {
                     'id': 'test',
@@ -43,6 +58,7 @@ return_values = {
                     ]
                 }
             ],
+            'server': SERVER_STATUS,
             'streams': [
                 {
                     'id': 'stream',
@@ -80,6 +96,7 @@ return_values = {
                   'clients': []
               }
           ],
+          'server': SERVER_STATUS,  # DeleteClient calls synchronize
           'streams': [
           ]
        }
@@ -120,7 +137,7 @@ class TestSnapserver(unittest.TestCase):
         self.server.synchronize(return_values.get('Server.GetStatus'))
 
     def test_init(self):
-        self.assertEqual(self.server.version, 0.11)
+        self.assertEqual(self.server.version, '0.12.0')
         self.assertEqual(len(self.server.clients), 1)
         self.assertEqual(len(self.server.groups), 1)
         self.assertEqual(len(self.server.streams), 1)
@@ -131,7 +148,7 @@ class TestSnapserver(unittest.TestCase):
     @mock.patch.object(Snapserver, '_transact', new=mock_transact('Server.GetStatus'))
     def test_status(self):
         status = self._run(self.server.status())
-        self.assertEqual(status.get('server').get('version'), 0.11)
+        self.assertEqual(status['server']['server']['snapserver']['version'], '0.12.0')
 
     @mock.patch.object(Snapserver, '_transact', new=mock_transact('Server.GetRPCVersion'))
     def test_rpc_version(self):
@@ -186,7 +203,7 @@ class TestSnapserver(unittest.TestCase):
 
     def test_synchronize(self):
         status = copy.deepcopy(return_values.get('Server.GetStatus'))
-        status['server']['version'] = '0.12'
+        status['server']['server']['snapserver']['version'] = '0.12'
         self.server.synchronize(status)
         self.assertEqual(self.server.version, '0.12')
 
@@ -207,7 +224,7 @@ class TestSnapserver(unittest.TestCase):
         cb = mock.MagicMock()
         self.server.set_on_update_callback(cb)
         status = copy.deepcopy(return_values.get('Server.GetStatus'))
-        status['server']['version'] = '0.12'
+        status['server']['server']['snapserver']['version'] = '0.12'
         self.server._on_server_update(status)
         self.assertEqual(self.server.version, '0.12')
         cb.assert_called_with()


### PR DESCRIPTION
Adds support for setting group names.
If the server is older than 0.16.0, will raise `ServerVersionError`.
Fixes server version parsing.
