### PR TITLE
Add basic support for new properties/metadata API

### DIFF
--- a/snapcast/control/stream.py
+++ b/snapcast/control/stream.py
@@ -30,9 +30,20 @@ class Snapstream(object):
         return self.name if self.name != '' else self.identifier
 
     @property
-    def meta(self):
+    def metadata(self):
         """Get metadata."""
+        if 'properties' in self._stream:
+            return self._stream['properties'].get('metadata')
         return self._stream.get('meta')
+
+    @property
+    def meta(self):
+        return self.metadata
+
+    @property
+    def properties(self):
+        """Get properties."""
+        return self._stream.get('properties')
 
     def update(self, data):
         """Update stream."""
@@ -40,7 +51,17 @@ class Snapstream(object):
 
     def update_meta(self, data):
         """Update stream metadata."""
+        self.update_metadata(data)
+
+    def update_metadata(self, data):
+        """Update stream metadata."""
+        if 'properties' in self._stream:
+            self._stream['properties']['metadata'] = data
         self._stream['meta'] = data
+
+    def update_properties(self, data):
+        """Update stream properties."""
+        self._stream['properties'] = data
 
     def __repr__(self):
         """String representation."""

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -5,7 +5,7 @@ from snapcast.control.stream import Snapstream
 class TestSnapstream(unittest.TestCase):
 
     def setUp(self):
-        data = {
+        data_meta = {
             'id': 'test',
             'status': 'playing',
             'uri': {
@@ -17,6 +17,22 @@ class TestSnapstream(unittest.TestCase):
                 'TITLE': 'Happy!',
             }
         }
+        data = {
+            'id': 'test',
+            'status': 'playing',
+            'uri': {
+                'query': {
+                    'name': ''
+                }
+            },
+            'properties': {
+                'canControl': False,
+                'metadata': {
+                    'title': 'Happy!',
+                }
+            }
+        }
+        self.stream_meta = Snapstream(data_meta)
         self.stream = Snapstream(data)
 
     def test_init(self):
@@ -24,7 +40,10 @@ class TestSnapstream(unittest.TestCase):
         self.assertEqual(self.stream.status, 'playing')
         self.assertEqual(self.stream.name, '')
         self.assertEqual(self.stream.friendly_name, 'test')
-        self.assertDictEqual(self.stream.meta, {'TITLE': 'Happy!'})
+        self.assertDictEqual(self.stream_meta.meta, {'TITLE': 'Happy!'})
+        self.assertDictEqual(self.stream.properties['metadata'], {'title': 'Happy!'})
+        self.assertDictEqual(self.stream.properties, {'canControl': False, 'metadata': {'title': 'Happy!',}})
+        self.assertDictEqual(self.stream.metadata, {'title': 'Happy!'})
 
     def test_update(self):
         self.stream.update({
@@ -34,11 +53,37 @@ class TestSnapstream(unittest.TestCase):
         self.assertEqual(self.stream.status, 'idle')
 
     def test_update_meta(self):
-        self.stream.update_meta({
+        self.stream_meta.update_meta({
             'TITLE': 'Unhappy!'
         })
-        self.assertDictEqual(self.stream.meta, {
+        self.assertDictEqual(self.stream_meta.meta, {
             'TITLE': 'Unhappy!'
+        })
+        # Verify that other attributes are still present
+        self.assertEqual(self.stream.status, 'playing')
+
+    def test_update_metadata(self):
+        self.stream.update_metadata({
+            'title': 'Unhappy!'
+        })
+        self.assertDictEqual(self.stream.metadata, {
+            'title': 'Unhappy!'
+        })
+        # Verify that other attributes are still present
+        self.assertEqual(self.stream.status, 'playing')
+
+    def test_update_properties(self):
+        self.stream.update_properties({
+            'canControl': True,
+            'metadata': {
+                'title': 'Unhappy!',
+            }
+        })
+        self.assertDictEqual(self.stream.properties, {
+            'canControl': True,
+            'metadata': {
+                'title': 'Unhappy!',
+            }
         })
         # Verify that other attributes are still present
         self.assertEqual(self.stream.status, 'playing')


### PR DESCRIPTION
In snapcast 0.26.0 (https://github.com/badaix/snapcast/releases/tag/v0.26.0) a new metadata API was introduced. There was already a metadata implementation based on @frafall's work (#20, #33), but this does no longer work with the current official snapcast server.

This pull request adds basic support for
- Stream.SetProperty
- Stream.OnProperties
- New property: stream.properties
- New property: stream.metadata (shortcut for stream.properties['metadata'] or stream.meta)
- New function: stream_setproperty

Documentation for the new APT: https://github.com/badaix/snapcast/blob/develop/doc/json_rpc_api/stream_plugin.md#pluginstreamplayergetproperties

The old stream.meta API is still functional.
