### PR TITLE
Update objects instead of recreating them on server update

### DIFF
--- a/snapcast/control/client.py
+++ b/snapcast/control/client.py
@@ -16,6 +16,10 @@ class Snapclient(object):
         self._snapshot = None
         self._last_seen = None
         self._callback_func = None
+        self.update(data)
+
+    def update(self, data):
+        """Update client."""
         self._client = data
 
     @property

--- a/snapcast/control/server.py
+++ b/snapcast/control/server.py
@@ -234,18 +234,33 @@ class Snapserver(object):
     def synchronize(self, status):
         """Synchronize snapserver."""
         self._version = status['server']['server']['snapserver']['version']
-        self._groups = {}
-        self._clients = {}
-        self._streams = {}
+        new_groups = {}
+        new_clients = {}
+        new_streams = {}
         for stream in status.get('server').get('streams'):
-            self._streams[stream.get('id')] = Snapstream(stream)
-            _LOGGER.debug('stream found: %s', self._streams[stream.get('id')])
+            if stream.get('id') in self._streams:
+                new_streams[stream.get('id')] = self._streams[stream.get('id')]
+                new_streams[stream.get('id')].update(stream)
+            else:
+                new_streams[stream.get('id')] = Snapstream(stream)
+            _LOGGER.debug('stream found: %s', new_streams[stream.get('id')])
         for group in status.get('server').get('groups'):
-            self._groups[group.get('id')] = Snapgroup(self, group)
-            _LOGGER.debug('group found: %s', self._groups[group.get('id')])
+            if group.get('id') in self._groups:
+                new_groups[group.get('id')] = self._groups[group.get('id')]
+                new_groups[group.get('id')].update(group)
+            else:
+                new_groups[group.get('id')] = Snapgroup(self, group)
+            _LOGGER.debug('group found: %s', new_groups[group.get('id')])
             for client in group.get('clients'):
-                self._clients[client.get('id')] = Snapclient(self, client)
-                _LOGGER.debug('client found: %s', self._clients[client.get('id')])
+                if client.get('id') in self._clients:
+                    new_clients[client.get('id')] = self._clients[client.get('id')]
+                    new_clients[client.get('id')].update(client)
+                else:
+                    new_clients[client.get('id')] = Snapclient(self, client)
+                _LOGGER.debug('client found: %s', new_clients[client.get('id')])
+        self._groups = new_groups
+        self._clients = new_clients
+        self._streams = new_streams
 
     @asyncio.coroutine
     def _request(self, method, identifier, key=None, value=None):


### PR DESCRIPTION
This addresses #41. Instead of throwing away all client, group and stream objects and recreate them the objects are updated. This preserves callbacks and makes the handling easier.

Let me know if you have any objections against this update. Of course it could be handled also by the application, e.g. home-assistant, but would be more cumbersome in my opinion.