### PR TITLE
Fix Python 3.11

### DIFF
--- a/snapcast/control/__init__.py
+++ b/snapcast/control/__init__.py
@@ -1,6 +1,5 @@
 """Snapcast control for Snapcast 0.11.1."""
 
-import asyncio
 from snapcast.control.server import Snapserver, CONTROL_PORT
 
 

--- a/snapcast/control/__init__.py
+++ b/snapcast/control/__init__.py
@@ -4,9 +4,8 @@ import asyncio
 from snapcast.control.server import Snapserver, CONTROL_PORT
 
 
-@asyncio.coroutine
-def create_server(loop, host, port=CONTROL_PORT, reconnect=False):
+async def create_server(loop, host, port=CONTROL_PORT, reconnect=False):
     """Server factory."""
     server = Snapserver(loop, host, port, reconnect)
-    yield from server.start()
+    await server.start()
     return server

--- a/snapcast/control/client.py
+++ b/snapcast/control/client.py
@@ -1,5 +1,4 @@
 """Snapcast client."""
-import asyncio
 import logging
 
 
@@ -7,7 +6,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 # pylint: disable=too-many-public-methods
-class Snapclient(object):
+class Snapclient():
     """Represents a snapclient."""
 
     def __init__(self, server, data):
@@ -105,7 +104,7 @@ class Snapclient(object):
 
     def groups_available(self):
         """Get available group objects."""
-        return [group for group in self._server.groups]
+        return list(self._server.groups)
 
     def update_volume(self, data):
         """Update volume."""
@@ -164,5 +163,4 @@ class Snapclient(object):
 
     def __repr__(self):
         """String representation."""
-        return 'Snapclient {} ({}, {})'.format(
-            self.version, self.friendly_name, self.identifier)
+        return f'Snapclient {self.version} ({self.friendly_name}, {self.identifier})'

--- a/snapcast/control/client.py
+++ b/snapcast/control/client.py
@@ -56,37 +56,34 @@ class Snapclient(object):
         """Name."""
         return self._client.get('config').get('name')
 
-    @asyncio.coroutine
-    def set_name(self, name):
+    async def set_name(self, name):
         """Set a client name."""
         if not name:
             name = ''
         self._client['config']['name'] = name
-        yield from self._server.client_name(self.identifier, name)
+        await self._server.client_name(self.identifier, name)
 
     @property
     def latency(self):
         """Latency."""
         return self._client.get('config').get('latency')
 
-    @asyncio.coroutine
-    def set_latency(self, latency):
+    async def set_latency(self, latency):
         """Set client latency."""
         self._client['config']['latency'] = latency
-        yield from self._server.client_latency(self.identifier, latency)
+        await self._server.client_latency(self.identifier, latency)
 
     @property
     def muted(self):
         """Muted or not."""
         return self._client.get('config').get('volume').get('muted')
 
-    @asyncio.coroutine
-    def set_muted(self, status):
+    async def set_muted(self, status):
         """Set client mute status."""
         new_volume = self._client['config']['volume']
         new_volume['muted'] = status
         self._client['config']['volume']['muted'] = status
-        yield from self._server.client_volume(self.identifier, new_volume)
+        await self._server.client_volume(self.identifier, new_volume)
         _LOGGER.info('set muted to %s on %s', status, self.friendly_name)
 
     @property
@@ -94,15 +91,14 @@ class Snapclient(object):
         """Volume percent."""
         return self._client.get('config').get('volume').get('percent')
 
-    @asyncio.coroutine
-    def set_volume(self, percent, update_group=True):
+    async def set_volume(self, percent, update_group=True):
         """Set client volume percent."""
         if percent not in range(0, 101):
             raise ValueError('Volume percent out of range')
         new_volume = self._client['config']['volume']
         new_volume['percent'] = percent
         self._client['config']['volume']['percent'] = percent
-        yield from self._server.client_volume(self.identifier, new_volume)
+        await self._server.client_volume(self.identifier, new_volume)
         if update_group:
             self._server.group(self.group.identifier).callback()
         _LOGGER.info('set volume to %s on %s', percent, self.friendly_name)
@@ -146,15 +142,14 @@ class Snapclient(object):
         }
         _LOGGER.info('took snapshot of current state of %s', self.friendly_name)
 
-    @asyncio.coroutine
-    def restore(self):
+    async def restore(self):
         """Restore snapshotted state."""
         if not self._snapshot:
             return
-        yield from self.set_name(self._snapshot['name'])
-        yield from self.set_volume(self._snapshot['volume'])
-        yield from self.set_muted(self._snapshot['muted'])
-        yield from self.set_latency(self._snapshot['latency'])
+        await self.set_name(self._snapshot['name'])
+        await self.set_volume(self._snapshot['volume'])
+        await self.set_muted(self._snapshot['muted'])
+        await self.set_latency(self._snapshot['latency'])
         self.callback()
         _LOGGER.info('restored snapshot of state of %s', self.friendly_name)
 

--- a/snapcast/control/group.py
+++ b/snapcast/control/group.py
@@ -1,5 +1,4 @@
 """Snapcast group."""
-import asyncio
 import logging
 
 
@@ -7,7 +6,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 # pylint: disable=too-many-public-methods
-class Snapgroup(object):
+class Snapgroup():
     """Represents a snapcast group."""
 
     def __init__(self, server, data):
@@ -190,4 +189,4 @@ class Snapgroup(object):
 
     def __repr__(self):
         """String representation."""
-        return 'Snapgroup ({}, {})'.format(self.friendly_name, self.identifier)
+        return f'Snapgroup ({self.friendly_name}, {self.identifier})'

--- a/snapcast/control/protocol.py
+++ b/snapcast/control/protocol.py
@@ -31,9 +31,9 @@ class SnapcastProtocol(asyncio.Protocol):
         """When a connection is made."""
         self._transport = transport
 
-    def connection_lost(self, exception):
+    def connection_lost(self, exc):
         """When a connection is lost."""
-        self._callbacks.get(SERVER_ONDISCONNECT)(exception)
+        self._callbacks.get(SERVER_ONDISCONNECT)(exc)
 
     def data_received(self, data):
         """Handle received data."""

--- a/snapcast/control/protocol.py
+++ b/snapcast/control/protocol.py
@@ -68,13 +68,12 @@ class SnapcastProtocol(asyncio.Protocol):
         if data.get('method') in self._callbacks:
             self._callbacks.get(data.get('method'))(data.get('params'))
 
-    @asyncio.coroutine
-    def request(self, method, params):
+    async def request(self, method, params):
         """Send a JSONRPC request."""
         identifier = random.randint(1, 1000)
         self._transport.write(jsonrpc_request(method, identifier, params))
         self._buffer[identifier] = {'flag': asyncio.Event()}
-        yield from self._buffer[identifier]['flag'].wait()
+        await self._buffer[identifier]['flag'].wait()
         result = self._buffer[identifier]['data']
         error = self._buffer[identifier]['error']
         del self._buffer[identifier]['data']

--- a/snapcast/control/server.py
+++ b/snapcast/control/server.py
@@ -40,10 +40,10 @@ GROUP_ONNAMECHANGED = 'Group.OnNameChanged'
 
 STREAM_ONPROPERTIES = 'Stream.OnProperties'
 STREAM_SETPROPERTY = 'Stream.SetProperty'
-STREAM_CONTROL = 'Stream.Control' #not yet implemented
-STREAM_SETMETA = 'Stream.SetMeta' #deprecated
+STREAM_CONTROL = 'Stream.Control'  # not yet implemented
+STREAM_SETMETA = 'Stream.SetMeta'  # deprecated
 STREAM_ONUPDATE = 'Stream.OnUpdate'
-STREAM_ONMETA = 'Stream.OnMetadata' #deprecated
+STREAM_ONMETA = 'Stream.OnMetadata'  # deprecated
 
 SERVER_RECONNECT_DELAY = 5
 
@@ -69,7 +69,7 @@ class ServerVersionError(NotImplementedError):
 
 
 # pylint: disable=too-many-public-methods
-class Snapserver(object):
+class Snapserver():
     """Represents a snapserver."""
 
     # pylint: disable=too-many-instance-attributes
@@ -226,14 +226,17 @@ class Snapserver(object):
         self._version_check(STREAM_SETPROPERTY)
         return self._request(STREAM_CONTROL, identifier, 'command', control_command, control_params)
 
-    def stream_setmeta(self, identifier, meta): #deprecated
+    def stream_setmeta(self, identifier, meta):  # deprecated
         """Set stream metadata."""
         return self._request(STREAM_SETMETA, identifier, 'meta', meta)
 
     def stream_setproperty(self, identifier, stream_property, value):
         """Set stream metadata."""
         self._version_check(STREAM_SETPROPERTY)
-        return self._request(STREAM_SETPROPERTY, identifier, parameters = {'property': stream_property, 'value': value})
+        return self._request(STREAM_SETPROPERTY, identifier, parameters={
+            'property': stream_property,
+            'value': value
+            })
 
     def group(self, group_identifier):
         """Get a group."""
@@ -298,10 +301,10 @@ class Snapserver(object):
         params = {'id': identifier}
         if key is not None and value is not None:
             params[key] = value
-        if type(parameters) is dict:
+        if isinstance(parameters, dict):
             params.update(parameters)
         result = await self._transact(method, params)
-        if type(result) is dict and key in result:
+        if isinstance(result, dict) and key in result:
             return result.get(key)
         return result
 
@@ -377,7 +380,7 @@ class Snapserver(object):
         """Handle client latency changed."""
         self._clients.get(data.get('id')).update_latency(data)
 
-    def _on_stream_meta(self, data): #deprecated
+    def _on_stream_meta(self, data):  # deprecated
         """Handle stream metadata update."""
         stream = self._streams[data.get('id')]
         stream.update_meta(data.get('meta'))
@@ -426,10 +429,11 @@ class Snapserver(object):
 
     def __repr__(self):
         """String representation."""
-        return 'Snapserver {} ({})'.format(self.version, self._host)
+        return f'Snapserver {self.version} ({self._host})'
 
     def _version_check(self, api_call):
         if version.parse(self.version) < version.parse(_VERSIONS.get(api_call)):
             raise ServerVersionError(
-                f"{api_call} requires server version >= {_VERSIONS[api_call]}. Current version is {self.version}"
+                f"{api_call} requires server version >= {_VERSIONS[api_call]}."
+                + f" Current version is {self.version}"
             )

--- a/snapcast/control/stream.py
+++ b/snapcast/control/stream.py
@@ -1,7 +1,7 @@
 """Snapcast stream."""
 
 
-class Snapstream(object):
+class Snapstream():
     """Represents a snapcast stream."""
 
     def __init__(self, data):
@@ -38,6 +38,7 @@ class Snapstream(object):
 
     @property
     def meta(self):
+        """Get metadata. Deprecated."""
         return self.metadata
 
     @property
@@ -65,7 +66,7 @@ class Snapstream(object):
 
     def __repr__(self):
         """String representation."""
-        return 'Snapstream ({})'.format(self.name)
+        return f'Snapstream ({self.name})'
 
     def callback(self):
         """Run callback."""

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,19 +1,7 @@
 """Asyncio test helpers from https://blog.miguelgrinberg.com/post/unit-testing-asyncio-code"""
 
 import asyncio
-from unittest import mock
 
 
 def async_run(coro):
-    return asyncio.get_event_loop().run_until_complete(coro)
-
-
-def AsyncMock(*args, **kwargs):
-    m = mock.MagicMock(*args, **kwargs)
-
-    @asyncio.coroutine
-    def mock_coro(*args, **kwargs):
-        return m(*args, **kwargs)
-
-    mock_coro.mock = m
-    return mock_coro
+    return asyncio.run(coro)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,6 +1,6 @@
 import unittest
 from unittest import mock
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, AsyncMock
 from helpers import async_run
 
 from snapcast.control.client import Snapclient
@@ -28,7 +28,11 @@ class TestSnapclient(unittest.TestCase):
             },
             'connected': True
         }
-        server = MagicMock()
+        server = AsyncMock()
+        server.synchronize = MagicMock()
+        group = AsyncMock()
+        group.callback = MagicMock()
+        server.group = MagicMock(return_value=group)
         server.groups = ['test_group']
         self.client = Snapclient(server, data)
 

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, AsyncMock
 from helpers import async_run
 
 from snapcast.control.group import Snapgroup
@@ -18,12 +18,15 @@ class TestSnapgroup(unittest.TestCase):
                 {'id': 'b'}
             ]
         }
-        server = MagicMock()
+        server = AsyncMock()
+        server.synchronize = MagicMock()
         stream = MagicMock()
         stream.friendly_name = 'test stream'
         stream.status = 'playing'
-        client = MagicMock()
+        client = AsyncMock()
         client.volume = 50
+        client.callback = MagicMock()
+        client.update_volume = MagicMock()
         server.streams = [stream]
         server.stream = MagicMock(return_value=stream)
         server.client = MagicMock(return_value=client)
@@ -61,11 +64,11 @@ class TestSnapgroup(unittest.TestCase):
         self.assertEqual(self.group.name, 'test')
 
     def test_add_client(self):
-        self.group.add_client('c')
+        async_run(self.group.add_client('c'))
         # TODO: add assert
 
     def test_remove_client(self):
-        self.group.remove_client('a')
+        async_run(self.group.remove_client('a'))
         # TODO: add assert
 
     def test_streams_by_name(self):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2,7 +2,7 @@ import asyncio
 import copy
 import unittest
 from unittest import mock
-from helpers import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 from snapcast.control.server import Snapserver
 from snapcast.control import create_server
@@ -135,11 +135,11 @@ def mock_transact(key):
 class TestSnapserver(unittest.TestCase):
 
     def _run(self, coro):
-        return self.loop.run_until_complete(coro)
+        return asyncio.run(coro)
 
     @mock.patch.object(Snapserver, 'start', new=AsyncMock())
     def setUp(self):
-        self.loop = asyncio.get_event_loop()
+        self.loop = MagicMock()
         self.server = self._run(create_server(self.loop, 'abcd'))
         self.server.synchronize(return_values.get('Server.GetStatus'))
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -122,11 +122,9 @@ return_values = {
         'clients': ['test']
     },
     'Stream.SetMeta': {
-        'id': 'stream'
+        'foo': 'bar'
     },
-    'Stream.SetProperty': {
-        'id': 'stream'
-    }
+    'Stream.SetProperty': 'ok'
 }
 
 
@@ -208,12 +206,12 @@ class TestSnapserver(unittest.TestCase):
     @mock.patch.object(Snapserver, '_transact', new=mock_transact('Stream.SetMeta'))
     def test_stream_setmeta(self):
         result = self._run(self.server.stream_setmeta('stream', {'foo': 'bar'}))
-        self.assertIsNone(result)
+        self.assertEqual(result, {'foo': 'bar'})
 
     @mock.patch.object(Snapserver, '_transact', new=mock_transact('Stream.SetProperty'))
     def test_stream_setproperty(self):
-        result = self._run(self.server.stream_setproperty('stream', {'foo': 'bar'}))
-        self.assertIsNone(result)
+        result = self._run(self.server.stream_setproperty('stream', 'foo', 'bar'))
+        self.assertEqual(result, 'ok')
 
     def test_synchronize(self):
         status = copy.deepcopy(return_values.get('Server.GetStatus'))

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35, lint
+envlist = py310, py311, lint
 skip_missing_interpreters = True
 
 [tool:pytest]
@@ -18,12 +18,12 @@ setenv =
     PYTHONPATH={toxinidir}:{toxinidir}/snapcast
     PYTHON_ENV=test
 deps =
-    pytest==3.0.4
-    pytest-cov==2.4.0
-    pytest-sugar==0.8.0
-    pylint==1.6.4
-    flake8==3.2.1
-    pydocstyle==1.1.1
+    pytest
+    pytest-cov
+    pytest-sugar
+    pylint
+    flake8
+    pydocstyle
 
 commands =
     py.test --cov-report term-missing --cov snapcast


### PR DESCRIPTION
Replaced asyncio.coroutine with async/await. With this it should be ready for python 3.11.
Additionally, I updated tox.ini, fixed the tests and most linter errors. Still the tests could be improved a lot, but I will leave that for someone else.
Pytest is clean for 3.10 and 3.11 and I run a quick test in my home-assistant container. tox still shows a few linter warnings. 

@happyleavesaoc: Could you please make a new release after merging?

Fix #51 