### PR TITLE
Change group friendly_name fallback to client names

### DIFF
--- a/snapcast/control/group.py
+++ b/snapcast/control/group.py
@@ -105,7 +105,8 @@ class Snapgroup():
     @property
     def friendly_name(self):
         """Get friendly name."""
-        return self.name if self.name != '' else self.stream
+        return self.name if self.name != '' else "+".join(
+            sorted([self._server.client(c).friendly_name for c in self.clients]))
 
     @property
     def clients(self):

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -27,6 +27,7 @@ class TestSnapgroup(unittest.TestCase):
         client.volume = 50
         client.callback = MagicMock()
         client.update_volume = MagicMock()
+        client.friendly_name = 'A'
         server.streams = [stream]
         server.stream = MagicMock(return_value=stream)
         server.client = MagicMock(return_value=client)
@@ -35,7 +36,7 @@ class TestSnapgroup(unittest.TestCase):
     def test_init(self):
         self.assertEqual(self.group.identifier, 'test')
         self.assertEqual(self.group.name, '')
-        self.assertEqual(self.group.friendly_name, 'test stream')
+        self.assertEqual(self.group.friendly_name, 'A+A')
         self.assertEqual(self.group.stream, 'test stream')
         self.assertEqual(self.group.muted, False)
         self.assertEqual(self.group.volume, 50)


### PR DESCRIPTION
This PR changes the `group.friendly_name` fallback from the stream name to client names. Eg. Client1+Client2
With this the group can be easily identified and keeps the same name if the clients are the same even if it is dynamically recreated and thus the id changes.

Close #54 