### PR TITLE
Reduce log verbosity

### DIFF
--- a/snapcast/control/client.py
+++ b/snapcast/control/client.py
@@ -83,7 +83,7 @@ class Snapclient():
         new_volume['muted'] = status
         self._client['config']['volume']['muted'] = status
         await self._server.client_volume(self.identifier, new_volume)
-        _LOGGER.info('set muted to %s on %s', status, self.friendly_name)
+        _LOGGER.debug('set muted to %s on %s', status, self.friendly_name)
 
     @property
     def volume(self):
@@ -100,7 +100,7 @@ class Snapclient():
         await self._server.client_volume(self.identifier, new_volume)
         if update_group:
             self._server.group(self.group.identifier).callback()
-        _LOGGER.info('set volume to %s on %s', percent, self.friendly_name)
+        _LOGGER.debug('set volume to %s on %s', percent, self.friendly_name)
 
     def groups_available(self):
         """Get available group objects."""
@@ -109,26 +109,26 @@ class Snapclient():
     def update_volume(self, data):
         """Update volume."""
         self._client['config']['volume'] = data['volume']
-        _LOGGER.info('updated volume on %s', self.friendly_name)
+        _LOGGER.debug('updated volume on %s', self.friendly_name)
         self._server.group(self.group.identifier).callback()
         self.callback()
 
     def update_name(self, data):
         """Update name."""
         self._client['config']['name'] = data['name']
-        _LOGGER.info('updated name on %s', self.friendly_name)
+        _LOGGER.debug('updated name on %s', self.friendly_name)
         self.callback()
 
     def update_latency(self, data):
         """Update latency."""
         self._client['config']['latency'] = data['latency']
-        _LOGGER.info('updated latency on %s', self.friendly_name)
+        _LOGGER.debug('updated latency on %s', self.friendly_name)
         self.callback()
 
     def update_connected(self, status):
         """Update connected."""
         self._client['connected'] = status
-        _LOGGER.info('updated connected status to %s on %s', status, self.friendly_name)
+        _LOGGER.debug('updated connected status to %s on %s', status, self.friendly_name)
         self.callback()
 
     def snapshot(self):
@@ -139,7 +139,7 @@ class Snapclient():
             'muted': self.muted,
             'latency': self.latency
         }
-        _LOGGER.info('took snapshot of current state of %s', self.friendly_name)
+        _LOGGER.debug('took snapshot of current state of %s', self.friendly_name)
 
     async def restore(self):
         """Restore snapshotted state."""
@@ -150,7 +150,7 @@ class Snapclient():
         await self.set_muted(self._snapshot['muted'])
         await self.set_latency(self._snapshot['latency'])
         self.callback()
-        _LOGGER.info('restored snapshot of state of %s', self.friendly_name)
+        _LOGGER.debug('restored snapshot of state of %s', self.friendly_name)
 
     def callback(self):
         """Run callback."""

--- a/snapcast/control/group.py
+++ b/snapcast/control/group.py
@@ -46,7 +46,7 @@ class Snapgroup():
         """Set group stream."""
         self._group['stream_id'] = stream_id
         await self._server.group_stream(self.identifier, stream_id)
-        _LOGGER.info('set stream to %s on %s', stream_id, self.friendly_name)
+        _LOGGER.debug('set stream to %s on %s', stream_id, self.friendly_name)
 
     @property
     def stream_status(self):
@@ -62,7 +62,7 @@ class Snapgroup():
         """Set group mute status."""
         self._group['muted'] = status
         await self._server.group_mute(self.identifier, status)
-        _LOGGER.info('set muted to %s on %s', status, self.friendly_name)
+        _LOGGER.debug('set muted to %s on %s', status, self.friendly_name)
 
     @property
     def volume(self):
@@ -78,7 +78,7 @@ class Snapgroup():
             raise ValueError('Volume out of range')
         current_volume = self.volume
         if volume == current_volume:
-            _LOGGER.info('left volume at %s on group %s', volume, self.friendly_name)
+            _LOGGER.debug('left volume at %s on group %s', volume, self.friendly_name)
             return
         delta = volume - current_volume
         if delta < 0:
@@ -100,7 +100,7 @@ class Snapgroup():
                     'muted': client.muted
                 }
             })
-        _LOGGER.info('set volume to %s on group %s', volume, self.friendly_name)
+        _LOGGER.debug('set volume to %s on group %s', volume, self.friendly_name)
 
     @property
     def friendly_name(self):
@@ -121,7 +121,7 @@ class Snapgroup():
         new_clients = self.clients
         new_clients.append(client_identifier)
         await self._server.group_clients(self.identifier, new_clients)
-        _LOGGER.info('added %s to %s', client_identifier, self.identifier)
+        _LOGGER.debug('added %s to %s', client_identifier, self.identifier)
         status = await self._server.status()
         self._server.synchronize(status)
         self._server.client(client_identifier).callback()
@@ -132,7 +132,7 @@ class Snapgroup():
         new_clients = self.clients
         new_clients.remove(client_identifier)
         await self._server.group_clients(self.identifier, new_clients)
-        _LOGGER.info('removed %s from %s', client_identifier, self.identifier)
+        _LOGGER.debug('removed %s from %s', client_identifier, self.identifier)
         status = await self._server.status()
         self._server.synchronize(status)
         self._server.client(client_identifier).callback()
@@ -146,19 +146,19 @@ class Snapgroup():
         """Update mute."""
         self._group['muted'] = data['mute']
         self.callback()
-        _LOGGER.info('updated mute on %s', self.friendly_name)
+        _LOGGER.debug('updated mute on %s', self.friendly_name)
 
     def update_name(self, data):
         """Update name."""
         self._group['name'] = data['name']
-        _LOGGER.info('updated name on %s', self.name)
+        _LOGGER.debug('updated name on %s', self.name)
         self.callback()
 
     def update_stream(self, data):
         """Update stream."""
         self._group['stream_id'] = data['stream_id']
         self.callback()
-        _LOGGER.info('updated stream to %s on %s', self.stream, self.friendly_name)
+        _LOGGER.debug('updated stream to %s on %s', self.stream, self.friendly_name)
 
     def snapshot(self):
         """Snapshot current state."""
@@ -167,7 +167,7 @@ class Snapgroup():
             'volume': self.volume,
             'stream': self.stream
         }
-        _LOGGER.info('took snapshot of current state of %s', self.friendly_name)
+        _LOGGER.debug('took snapshot of current state of %s', self.friendly_name)
 
     async def restore(self):
         """Restore snapshotted state."""
@@ -177,7 +177,7 @@ class Snapgroup():
         await self.set_volume(self._snapshot['volume'])
         await self.set_stream(self._snapshot['stream'])
         self.callback()
-        _LOGGER.info('restored snapshot of state of %s', self.friendly_name)
+        _LOGGER.debug('restored snapshot of state of %s', self.friendly_name)
 
     def callback(self):
         """Run callback."""

--- a/snapcast/control/server.py
+++ b/snapcast/control/server.py
@@ -110,7 +110,7 @@ class Snapserver():
         """Initiate server connection."""
         self._is_stopped = False
         await self._do_connect()
-        _LOGGER.info('connected to snapserver on %s:%s', self._host, self._port)
+        _LOGGER.debug('connected to snapserver on %s:%s', self._host, self._port)
         status = await self.status()
         self.synchronize(status)
         self._on_server_connect()
@@ -119,7 +119,7 @@ class Snapserver():
         """Stop server."""
         self._is_stopped = True
         self._do_disconnect()
-        _LOGGER.info('disconnected from snapserver on %s:%s', self._host, self._port)
+        _LOGGER.debug('disconnected from snapserver on %s:%s', self._host, self._port)
         self._clients = {}
         self._streams = {}
         self._groups = {}
@@ -139,7 +139,7 @@ class Snapserver():
 
     def _reconnect_cb(self):
         """Callback to reconnect to the server."""
-        _LOGGER.info('try reconnect')
+        _LOGGER.debug('try reconnect')
 
         async def try_reconnect():
             """Actual coroutine ro try to reconnect or reschedule."""
@@ -310,13 +310,13 @@ class Snapserver():
 
     def _on_server_connect(self):
         """Handle server connection."""
-        _LOGGER.info('Server connected')
+        _LOGGER.debug('Server connected')
         if self._on_connect_callback_func and callable(self._on_connect_callback_func):
             self._on_connect_callback_func()
 
     def _on_server_disconnect(self, exception):
         """Handle server disconnection."""
-        _LOGGER.info('Server disconnected')
+        _LOGGER.debug('Server disconnected')
         if self._on_disconnect_callback_func and callable(self._on_disconnect_callback_func):
             self._on_disconnect_callback_func(exception)
         if not self._is_stopped:
@@ -361,12 +361,12 @@ class Snapserver():
             self._clients[data.get('id')] = client
             if self._new_client_callback_func and callable(self._new_client_callback_func):
                 self._new_client_callback_func(client)
-        _LOGGER.info('client %s connected', client.friendly_name)
+        _LOGGER.debug('client %s connected', client.friendly_name)
 
     def _on_client_disconnect(self, data):
         """Handle client disconnect."""
         self._clients[data.get('id')].update_connected(False)
-        _LOGGER.info('client %s disconnected', self._clients[data.get('id')].friendly_name)
+        _LOGGER.debug('client %s disconnected', self._clients[data.get('id')].friendly_name)
 
     def _on_client_volume_changed(self, data):
         """Handle client volume change."""
@@ -384,7 +384,7 @@ class Snapserver():
         """Handle stream metadata update."""
         stream = self._streams[data.get('id')]
         stream.update_meta(data.get('meta'))
-        _LOGGER.info('stream %s metadata updated', stream.friendly_name)
+        _LOGGER.debug('stream %s metadata updated', stream.friendly_name)
         for group in self._groups.values():
             if group.stream == data.get('id'):
                 group.callback()
@@ -393,7 +393,7 @@ class Snapserver():
         """Handle stream properties update."""
         stream = self._streams[data.get('id')]
         stream.update_properties(data.get('properties'))
-        _LOGGER.info('stream %s properties updated', stream.friendly_name)
+        _LOGGER.debug('stream %s properties updated', stream.friendly_name)
         for group in self._groups.values():
             if group.stream == data.get('id'):
                 group.callback()
@@ -403,7 +403,7 @@ class Snapserver():
     def _on_stream_update(self, data):
         """Handle stream update."""
         self._streams[data.get('id')].update(data.get('stream'))
-        _LOGGER.info('stream %s updated', self._streams[data.get('id')].friendly_name)
+        _LOGGER.debug('stream %s updated', self._streams[data.get('id')].friendly_name)
         self._streams[data.get("id")].callback()
         for group in self._groups.values():
             if group.stream == data.get('id'):


### PR DESCRIPTION
Change log.info to log.debug as these messages are mainly needed for debugging. If info logging is needed this can be implemented in the higher-level application.