### PR TITLE
Fix group friendly name

### DIFF
--- a/snapcast/control/group.py
+++ b/snapcast/control/group.py
@@ -105,8 +105,10 @@ class Snapgroup():
     @property
     def friendly_name(self):
         """Get friendly name."""
-        return self.name if self.name != '' else "+".join(
-            sorted([self._server.client(c).friendly_name for c in self.clients]))
+        fname =  self.name if self.name != '' else "+".join(
+            sorted([self._server.client(c).friendly_name for c in self.clients
+                    if c in [client.identifier for client in self._server.clients]]))
+        return fname if fname != '' else self.identifier
 
     @property
     def clients(self):

--- a/snapcast/control/server.py
+++ b/snapcast/control/server.py
@@ -284,7 +284,6 @@ class Snapserver():
                 new_groups[group.get('id')].update(group)
             else:
                 new_groups[group.get('id')] = Snapgroup(self, group)
-            _LOGGER.debug('group found: %s', new_groups[group.get('id')])
             for client in group.get('clients'):
                 if client.get('id') in self._clients:
                     new_clients[client.get('id')] = self._clients[client.get('id')]
@@ -292,6 +291,7 @@ class Snapserver():
                 else:
                     new_clients[client.get('id')] = Snapclient(self, client)
                 _LOGGER.debug('client found: %s', new_clients[client.get('id')])
+            _LOGGER.debug('group found: %s', new_groups[group.get('id')])
         self._groups = new_groups
         self._clients = new_clients
         self._streams = new_streams

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -28,20 +28,25 @@ class TestSnapgroup(unittest.TestCase):
         client.callback = MagicMock()
         client.update_volume = MagicMock()
         client.friendly_name = 'A'
+        client.identifier = 'a'
         server.streams = [stream]
         server.stream = MagicMock(return_value=stream)
         server.client = MagicMock(return_value=client)
+        server.clients = [client]
         self.group = Snapgroup(server, data)
 
     def test_init(self):
         self.assertEqual(self.group.identifier, 'test')
         self.assertEqual(self.group.name, '')
-        self.assertEqual(self.group.friendly_name, 'A+A')
+        self.assertEqual(self.group.friendly_name, 'A')
         self.assertEqual(self.group.stream, 'test stream')
         self.assertEqual(self.group.muted, False)
         self.assertEqual(self.group.volume, 50)
         self.assertEqual(self.group.clients, ['a', 'b'])
         self.assertEqual(self.group.stream_status, 'playing')
+
+    def test_repr(self):
+        self.assertEqual(self.group.__repr__(), 'Snapgroup (A, test)')
 
     def test_update(self):
         self.group.update({


### PR DESCRIPTION
The groups friendly name method threw an exception during synchronize() because clients are not known to the server at this time.
Fix #61 