### PR TITLE
Fix connection related issues

### DIFF
--- a/snapcast/control/client.py
+++ b/snapcast/control/client.py
@@ -32,6 +32,7 @@ class Snapclient():
         for group in self._server.groups:
             if self.identifier in group.clients:
                 return group
+        return None
 
     @property
     def friendly_name(self):
@@ -162,5 +163,5 @@ class Snapclient():
         self._callback_func = func
 
     def __repr__(self):
-        """String representation."""
+        """Return string representation."""
         return f'Snapclient {self.version} ({self.friendly_name}, {self.identifier})'

--- a/snapcast/control/group.py
+++ b/snapcast/control/group.py
@@ -105,7 +105,7 @@ class Snapgroup():
     @property
     def friendly_name(self):
         """Get friendly name."""
-        fname =  self.name if self.name != '' else "+".join(
+        fname = self.name if self.name != '' else "+".join(
             sorted([self._server.client(c).friendly_name for c in self.clients
                     if c in [client.identifier for client in self._server.clients]]))
         return fname if fname != '' else self.identifier
@@ -191,5 +191,5 @@ class Snapgroup():
         self._callback_func = func
 
     def __repr__(self):
-        """String representation."""
+        """Return string representation."""
         return f'Snapgroup ({self.friendly_name}, {self.identifier})'

--- a/snapcast/control/group.py
+++ b/snapcast/control/group.py
@@ -124,7 +124,7 @@ class Snapgroup():
         new_clients.append(client_identifier)
         await self._server.group_clients(self.identifier, new_clients)
         _LOGGER.debug('added %s to %s', client_identifier, self.identifier)
-        status = await self._server.status()
+        status = (await self._server.status())[0]
         self._server.synchronize(status)
         self._server.client(client_identifier).callback()
         self.callback()
@@ -135,7 +135,7 @@ class Snapgroup():
         new_clients.remove(client_identifier)
         await self._server.group_clients(self.identifier, new_clients)
         _LOGGER.debug('removed %s from %s', client_identifier, self.identifier)
-        status = await self._server.status()
+        status = (await self._server.status())[0]
         self._server.synchronize(status)
         self._server.client(client_identifier).callback()
         self.callback()

--- a/snapcast/control/protocol.py
+++ b/snapcast/control/protocol.py
@@ -33,6 +33,9 @@ class SnapcastProtocol(asyncio.Protocol):
 
     def connection_lost(self, exc):
         """When a connection is lost."""
+        for b in self._buffer.values():
+            b['error'] = {"code": -1, "message": "connection lost"}
+            b['flag'].set()
         self._callbacks.get(SERVER_ONDISCONNECT)(exc)
 
     def data_received(self, data):
@@ -74,8 +77,8 @@ class SnapcastProtocol(asyncio.Protocol):
         self._transport.write(jsonrpc_request(method, identifier, params))
         self._buffer[identifier] = {'flag': asyncio.Event()}
         await self._buffer[identifier]['flag'].wait()
-        result = self._buffer[identifier]['data']
-        error = self._buffer[identifier]['error']
-        del self._buffer[identifier]['data']
-        del self._buffer[identifier]['error']
+        result = self._buffer[identifier].get('data')
+        error = self._buffer[identifier].get('error')
+        self._buffer[identifier].clear()
+        del self._buffer[identifier]
         return (result, error)

--- a/snapcast/control/protocol.py
+++ b/snapcast/control/protocol.py
@@ -7,6 +7,7 @@ import random
 SERVER_ONDISCONNECT = 'Server.OnDisconnect'
 
 
+# pylint: disable=consider-using-f-string
 def jsonrpc_request(method, identifier, params=None):
     """Produce a JSONRPC request."""
     return '{}\r\n'.format(json.dumps({

--- a/snapcast/control/stream.py
+++ b/snapcast/control/stream.py
@@ -65,7 +65,7 @@ class Snapstream():
         self._stream['properties'] = data
 
     def __repr__(self):
-        """String representation."""
+        """Return string representation."""
         return f'Snapstream ({self.name})'
 
     def callback(self):


### PR DESCRIPTION
This PR tries to solve a couple of connection related issues that happen only rarely:
1. Return waiting requests when the connection is lost. Before, the waiting task was stalled when the connection was lost while waiting for a server response. Maybe we should even add a timeout? Solves https://github.com/home-assistant/core/issues/106374
2. Verify on start and reconnect that we get a valid response.
3. Don't catch exception in `_transact()`. I have added this in #50 to get rid of them, but probably exceptions should be handled at a higher level. See #62
I am not completely sure what's the best approach here. Does an exception mean we need to resend or should we even renew the connection?
4. fix some small bugs with missing `await` statements.

I also added new tests for `start()` and fixed the pylint errors.
In general, error handling is missing in most cases. I think it would be a good idea to check the response whenever a request is send.