### PR TITLE
Improve error handling in delete_client method 

### DIFF
--- a/snapcast/control/server.py
+++ b/snapcast/control/server.py
@@ -191,9 +191,9 @@ class Snapserver():
         """Delete client."""
         params = {'id': identifier}
         response, error = await self._transact(SERVER_DELETECLIENT, params)
-        if (isinstance(response, dict) and ("id" in response)):
-            self.synchronize((await self.status())[0])
-        return response or error
+        if (isinstance(response, dict) and ("server" in response)):
+            self.synchronize(response)
+        return response, error
 
 
     async def client_name(self, identifier, name):

--- a/snapcast/control/server.py
+++ b/snapcast/control/server.py
@@ -190,8 +190,11 @@ class Snapserver():
     async def delete_client(self, identifier):
         """Delete client."""
         params = {'id': identifier}
-        response, _ = await self._transact(SERVER_DELETECLIENT, params)
-        self.synchronize(response)
+        response, error = await self._transact(SERVER_DELETECLIENT, params)
+        if (isinstance(response, dict) and ("id" in response)):
+            self.synchronize((await self.status())[0])
+        return response or error
+
 
     async def client_name(self, identifier, name):
         """Set client name."""


### PR DESCRIPTION
Added error handling to the delete_client method. If an error occurs (e.g., invalid client ID or request failure), the method no longer crashes and instead safely returns without raising an exception.