### PR TITLE
fix KeyError when stream_status is called on a group

### DIFF
--- a/snapcast/control/group.py
+++ b/snapcast/control/group.py
@@ -51,7 +51,10 @@ class Snapgroup():
     @property
     def stream_status(self):
         """Get stream status."""
-        return self._server.stream(self.stream).status
+        try:
+            return self._server.stream(self.stream).status
+        except KeyError:
+            return "unknown"
 
     @property
     def muted(self):

--- a/snapcast/control/server.py
+++ b/snapcast/control/server.py
@@ -376,7 +376,18 @@ class Snapserver():
     def _on_group_stream_changed(self, data):
         """Handle group stream change."""
         group = self._groups.get(data.get('id'))
-        self._synchronize_if_stream_missing(data.get('stream_id', None))
+        stream_id = data.get('stream_id', None)
+
+        if stream_id not in self._streams:
+            def update_callback():
+                self._on_update_callback_func()
+                group.update_stream(data)
+                for client_id in group.clients:
+                    self._clients.get(client_id).callback()
+
+            self._synchronize_if_stream_missing(stream_id, update_callback)
+            return
+
         group.update_stream(data)
         for client_id in group.clients:
             self._clients.get(client_id).callback()
@@ -446,9 +457,9 @@ class Snapserver():
             if data.get('stream', {}).get('uri', {}).get('query', {}).get('codec') == 'null':
                 _LOGGER.debug('stream %s is input-only, ignore', data.get('id'))
             else:
-                self._synchronize_if_stream_missing(data.get('id'))
+                self._synchronize_if_stream_missing(data.get('id'), self._on_update_callback_func)
 
-    def _synchronize_if_stream_missing(self, stream_id):
+    def _synchronize_if_stream_missing(self, stream_id, callback=None):
         """Ensure stream exists, otherwise synchronize."""
         if stream_id is None:
             return
@@ -457,8 +468,9 @@ class Snapserver():
 
             async def async_sync():
                 self.synchronize((await self.status())[0])
-                if self._on_update_callback_func and callable(self._on_update_callback_func):
-                    self._on_update_callback_func()
+                if callback and callable(callback):
+                    callback()
+
             asyncio.ensure_future(async_sync())
 
     def set_on_update_callback(self, func):

--- a/snapcast/control/server.py
+++ b/snapcast/control/server.py
@@ -272,6 +272,9 @@ class Snapserver():
 
     def stream(self, stream_identifier):
         """Get a stream."""
+        if stream_identifier not in self._streams:
+            self._synchronize_if_stream_missing(stream_identifier)
+            raise KeyError(f'Stream "{stream_identifier}" not found')
         return self._streams[stream_identifier]
 
     def client(self, client_identifier):
@@ -373,6 +376,7 @@ class Snapserver():
     def _on_group_stream_changed(self, data):
         """Handle group stream change."""
         group = self._groups.get(data.get('id'))
+        self._synchronize_if_stream_missing(data.get('stream_id', None))
         group.update_stream(data)
         for client_id in group.clients:
             self._clients.get(client_id).callback()
@@ -442,11 +446,18 @@ class Snapserver():
             if data.get('stream', {}).get('uri', {}).get('query', {}).get('codec') == 'null':
                 _LOGGER.debug('stream %s is input-only, ignore', data.get('id'))
             else:
-                _LOGGER.info('stream %s not found, synchronize', data.get('id'))
+                self._synchronize_if_stream_missing(data.get('id'))
 
-                async def async_sync():
-                    self.synchronize((await self.status())[0])
-                asyncio.ensure_future(async_sync())
+    def _synchronize_if_stream_missing(self, stream_id):
+        """Ensure stream exists, otherwise synchronize."""
+        if stream_id is None:
+            return
+        if stream_id not in self._streams:
+            _LOGGER.info('stream %s not found, synchronize', stream_id)
+
+            async def async_sync():
+                self.synchronize((await self.status())[0])
+            asyncio.ensure_future(async_sync())
 
     def set_on_update_callback(self, func):
         """Set on update callback function."""

--- a/snapcast/control/server.py
+++ b/snapcast/control/server.py
@@ -378,7 +378,7 @@ class Snapserver():
         stream_id = data.get('stream_id', None)
 
         if stream_id not in self._streams:
-            def update_callback(found):
+            def update_callback(found, stream_id):
                 self._on_update_callback_func()
                 if not found:
                     return
@@ -458,7 +458,10 @@ class Snapserver():
             if data.get('stream', {}).get('uri', {}).get('query', {}).get('codec') == 'null':
                 _LOGGER.debug('stream %s is input-only, ignore', data.get('id'))
             else:
-                self._synchronize_if_stream_missing(data.get('id'), self._on_update_callback_func)
+                def update_callback(found, stream_id):
+                    if self._on_update_callback_func and callable(self._on_update_callback_func):
+                        self._on_update_callback_func()
+                self._synchronize_if_stream_missing(data.get('id'), update_callback)
 
     def _synchronize_if_stream_missing(self, stream_id, callback=None):
         """Ensure stream exists, otherwise synchronize."""

--- a/snapcast/control/server.py
+++ b/snapcast/control/server.py
@@ -379,8 +379,10 @@ class Snapserver():
         stream_id = data.get('stream_id', None)
 
         if stream_id not in self._streams:
-            def update_callback():
+            def update_callback(found):
                 self._on_update_callback_func()
+                if not found:
+                    return
                 group.update_stream(data)
                 for client_id in group.clients:
                     self._clients.get(client_id).callback()
@@ -464,12 +466,15 @@ class Snapserver():
         if stream_id is None:
             return
         if stream_id not in self._streams:
-            _LOGGER.info('stream %s not found, synchronize', stream_id)
+            _LOGGER.info('stream "%s" not found, synchronize', stream_id)
 
             async def async_sync():
                 self.synchronize((await self.status())[0])
+                found = stream_id in self._streams
+                if not found:
+                    _LOGGER.warning('stream "%s" still not found after synchronization', stream_id)
                 if callback and callable(callback):
-                    callback()
+                    callback(found, stream_id)
 
             asyncio.ensure_future(async_sync())
 

--- a/snapcast/control/server.py
+++ b/snapcast/control/server.py
@@ -379,7 +379,8 @@ class Snapserver():
 
         if stream_id not in self._streams:
             def update_callback(found, stream_id):
-                self._on_update_callback_func()
+                if self._on_update_callback_func and callable(self._on_update_callback_func):
+                    self._on_update_callback_func()
                 if not found:
                     return
                 group.update_stream(data)

--- a/snapcast/control/server.py
+++ b/snapcast/control/server.py
@@ -273,7 +273,6 @@ class Snapserver():
     def stream(self, stream_identifier):
         """Get a stream."""
         if stream_identifier not in self._streams:
-            self._synchronize_if_stream_missing(stream_identifier)
             raise KeyError(f'Stream "{stream_identifier}" not found')
         return self._streams[stream_identifier]
 

--- a/snapcast/control/server.py
+++ b/snapcast/control/server.py
@@ -457,6 +457,8 @@ class Snapserver():
 
             async def async_sync():
                 self.synchronize((await self.status())[0])
+                if self._on_update_callback_func and callable(self._on_update_callback_func):
+                    self._on_update_callback_func()
             asyncio.ensure_future(async_sync())
 
     def set_on_update_callback(self, func):

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -101,3 +101,35 @@ class TestSnapgroup(unittest.TestCase):
         self.group.set_callback(cb)
         self.group.update_mute({'mute': True})
         cb.assert_called_with(self.group)
+
+    def test_bad_stream_status(self):
+        # Simulate a server where the requested stream id is missing
+        class DummyClient:
+            def __init__(self, identifier, friendly_name):
+                self.identifier = identifier
+                self.friendly_name = friendly_name
+
+        class DummyServer:
+            def __init__(self):
+                self._streams = {}
+                # provide clients list used by Snapgroup.friendly_name
+                self.clients = [DummyClient('a', 'A'), DummyClient('b', 'B')]
+
+            def stream(self, stream_identifier):
+                return self._streams[stream_identifier]
+
+            def client(self, identifier):
+                # return a client-like object for friendly_name lookup
+                for c in self.clients:
+                    if c.identifier == identifier:
+                        return c
+                raise KeyError(identifier)
+
+        # Replace the group's server with the dummy and set an unknown stream id
+        self.group._server = DummyServer()
+
+        # Updating the stream should not raise; accessing stream_status should
+        # not raise KeyError because the stream id is not present on the server.
+        self.group.update_stream({'stream_id': 'no stream'})
+        self.assertEqual(self.group.stream_status, 'unknown')
+

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -74,6 +74,21 @@ return_values = {
                             'title': 'Happy!',
                         }
                     }
+                },
+                {
+                    'id': 'stream2',
+                    'status': 'playing',
+                    'uri': {
+                        'query': {
+                            'name': 'stream2'
+                        }
+                    },
+                    'properties': {
+                        'canControl': False,
+                        'metadata': {
+                            'title': 'Happy2!',
+                        }
+                    }
                 }
             ]
         }
@@ -168,7 +183,7 @@ class TestSnapserver(unittest.TestCase):
         self.assertEqual(self.server.version, '0.26.0')
         self.assertEqual(len(self.server.clients), 1)
         self.assertEqual(len(self.server.groups), 1)
-        self.assertEqual(len(self.server.streams), 1)
+        self.assertEqual(len(self.server.streams), 2)
         self.assertEqual(self.server.group('test').identifier, 'test')
         self.assertEqual(self.server.stream('stream').identifier, 'stream')
         self.assertEqual(self.server.client('test').identifier, 'test')
@@ -286,11 +301,25 @@ class TestSnapserver(unittest.TestCase):
     def test_on_group_stream_changed(self, mock_sync):
         data = {
             'id': 'test',
+            'stream_id': 'stream2'
+        }
+        self.server._on_group_stream_changed(data)
+        self.assertEqual(self.server.group('test').stream, 'stream2')
+
+        mock_sync.assert_not_called()
+
+    @mock.patch.object(Snapserver, '_synchronize_if_stream_missing')
+    def test_on_group_stream_changed_no_stream(self, mock_sync):
+        data = {
+            'id': 'test',
             'stream_id': 'other'
         }
         self.server._on_group_stream_changed(data)
-        self.assertEqual(self.server.group('test').stream, 'other')
-        mock_sync.assert_called_with('other')
+        self.assertEqual(self.server.group('test').stream, 'stream2')
+
+        mock_sync.assert_called_once()
+        _, args, _ = mock_sync.mock_calls[0]
+        self.assertEqual('other', args[0])
 
     def test_on_client_connect(self):
         cb = mock.MagicMock()
@@ -347,7 +376,8 @@ class TestSnapserver(unittest.TestCase):
         self.server._on_client_latency_changed(data)
         self.assertEqual(self.server.client('test').latency, 50)
 
-    def test_on_stream_update(self):
+    @mock.patch.object(Snapserver, '_synchronize_if_stream_missing')
+    def test_on_stream_update(self, mock_sync):
         data = {
             'id': 'stream',
             'stream': {
@@ -362,6 +392,7 @@ class TestSnapserver(unittest.TestCase):
         }
         self.server._on_stream_update(data)
         self.assertEqual(self.server.stream('stream').status, 'idle')
+        mock_sync.assert_not_called()
 
     @mock.patch.object(Snapserver, '_synchronize_if_stream_missing')
     def test_on_stream_update_new(self, mock_sync):
@@ -378,7 +409,9 @@ class TestSnapserver(unittest.TestCase):
             }
         }
         self.server._on_stream_update(data)
-        mock_sync.assert_called_with('stream_new')
+        mock_sync.assert_called_once()
+        _, args, _ = mock_sync.mock_calls[0]
+        self.assertEqual('stream_new', args[0])
 
     def test_on_meta_update(self):
         data = {

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -282,13 +282,15 @@ class TestSnapserver(unittest.TestCase):
         self.server._on_group_mute(data)
         self.assertEqual(self.server.group('test').muted, True)
 
-    def test_on_group_stream_changed(self):
+    @mock.patch.object(Snapserver, '_synchronize_if_stream_missing')
+    def test_on_group_stream_changed(self, mock_sync):
         data = {
             'id': 'test',
             'stream_id': 'other'
         }
         self.server._on_group_stream_changed(data)
         self.assertEqual(self.server.group('test').stream, 'other')
+        mock_sync.assert_called_with('other')
 
     def test_on_client_connect(self):
         cb = mock.MagicMock()
@@ -360,6 +362,23 @@ class TestSnapserver(unittest.TestCase):
         }
         self.server._on_stream_update(data)
         self.assertEqual(self.server.stream('stream').status, 'idle')
+
+    @mock.patch.object(Snapserver, '_synchronize_if_stream_missing')
+    def test_on_stream_update_new(self, mock_sync):
+        data = {
+            'id': 'stream_new',
+            'stream': {
+                'id': 'stream_new',
+                'status': 'idle',
+                'uri': {
+                    'query': {
+                        'name': 'stream_new'
+                    }
+                }
+            }
+        }
+        self.server._on_stream_update(data)
+        mock_sync.assert_called_with('stream_new')
 
     def test_on_meta_update(self):
         data = {

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py310, py311, lint
+envlist = py310, py311, py313, lint
 skip_missing_interpreters = True
 
 [tool:pytest]


### PR DESCRIPTION
This pull request improves error handling in the `stream_status` property of the `Snapgroup` class and adds a corresponding unit test to ensure robustness when a requested stream is missing from the server.

Error handling improvements:

* Modified the `stream_status` property in `snapcast/control/group.py` to catch `KeyError` exceptions and return `"unknown"` if the stream ID is not found, preventing unhandled exceptions.

`"unknown"`  matches a valid state of the  snapcast server API:
https://github.com/snapcast/snapcast/blob/801c02eaa432e6715fd69a2b5d857d276c0e8c39/server/streamreader/properties.hpp#L62

Testing enhancements:

* Added a new test case `test_bad_stream_status` in `tests/test_group.py` to verify that `stream_status` returns `"unknown"` when the stream ID does not exist on the server, ensuring the new error handling logic works as expected.

Related to:
https://github.com/home-assistant/core/issues/157636