### PR TITLE
Make JSON-RPC request id allocation collision-free and resilient to cancellation

### DIFF
--- a/snapcast/control/protocol.py
+++ b/snapcast/control/protocol.py
@@ -83,9 +83,10 @@ class SnapcastProtocol(asyncio.Protocol):
         identifier = random.randint(1, 1000)
         self._transport.write(jsonrpc_request(method, identifier, params))
         self._buffer[identifier] = {'flag': asyncio.Event()}
-        await self._buffer[identifier]['flag'].wait()
-        result = self._buffer[identifier].get('data')
-        error = self._buffer[identifier].get('error')
-        self._buffer[identifier].clear()
-        del self._buffer[identifier]
-        return (result, error)
+        try:
+            await self._buffer[identifier]['flag'].wait()
+            result = self._buffer[identifier].get('data')
+            error = self._buffer[identifier].get('error')
+            return (result, error)
+        finally:
+            self._buffer.pop(identifier, None)

--- a/snapcast/control/protocol.py
+++ b/snapcast/control/protocol.py
@@ -2,7 +2,10 @@
 
 import asyncio
 import json
+import logging
 import threading
+
+_LOGGER = logging.getLogger(__name__)
 
 SERVER_ONDISCONNECT = 'Server.OnDisconnect'
 
@@ -70,6 +73,7 @@ class SnapcastProtocol(asyncio.Protocol):
             # late/orphan response: request was cancelled, connection was
             # re-established, or another response with the same id already
             # ran cleanup. Drop silently.
+            _LOGGER.debug("dropping response for unknown id %s", identifier)
             return
         entry['data'] = data.get('result')
         entry['error'] = data.get('error')

--- a/snapcast/control/protocol.py
+++ b/snapcast/control/protocol.py
@@ -63,9 +63,15 @@ class SnapcastProtocol(asyncio.Protocol):
     def handle_response(self, data):
         """Handle JSONRPC response."""
         identifier = data.get('id')
-        self._buffer[identifier]['data'] = data.get('result')
-        self._buffer[identifier]['error'] = data.get('error')
-        self._buffer[identifier]['flag'].set()
+        entry = self._buffer.get(identifier)
+        if entry is None:
+            # late/orphan response: request was cancelled, connection was
+            # re-established, or another response with the same id already
+            # ran cleanup. Drop silently.
+            return
+        entry['data'] = data.get('result')
+        entry['error'] = data.get('error')
+        entry['flag'].set()
 
     def handle_notification(self, data):
         """Handle JSONRPC notification."""

--- a/snapcast/control/protocol.py
+++ b/snapcast/control/protocol.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import json
-import random
+import threading
 
 SERVER_ONDISCONNECT = 'Server.OnDisconnect'
 
@@ -27,6 +27,8 @@ class SnapcastProtocol(asyncio.Protocol):
         self._buffer = {}
         self._callbacks = callbacks
         self._data_buffer = ''
+        self._next_id_lock = threading.Lock()
+        self._next_id_value = 0
 
     def connection_made(self, transport):
         """When a connection is made."""
@@ -78,9 +80,19 @@ class SnapcastProtocol(asyncio.Protocol):
         if data.get('method') in self._callbacks:
             self._callbacks.get(data.get('method'))(data.get('params'))
 
+    def _next_request_id(self) -> int:
+        """Allocate a unique JSON-RPC request id.
+
+        Explicit lock keeps allocation correct under both GIL and free-threaded
+        (PEP 703) CPython. itertools.count() atomicity is implementation-defined.
+        """
+        with self._next_id_lock:
+            self._next_id_value += 1
+            return self._next_id_value
+
     async def request(self, method, params):
         """Send a JSONRPC request."""
-        identifier = random.randint(1, 1000)
+        identifier = self._next_request_id()
         self._transport.write(jsonrpc_request(method, identifier, params))
         self._buffer[identifier] = {'flag': asyncio.Event()}
         try:

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -164,7 +164,7 @@ class TestConcurrentAsyncRequests(unittest.TestCase):
                 await asyncio.sleep(0)
                 return t
 
-            tasks = [await issue() for _ in range(200)]
+            tasks = await asyncio.gather(*(issue() for _ in range(200)))
             try:
                 ids = []
                 for raw in proto._transport.written:

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -14,6 +14,15 @@ from unittest.mock import MagicMock
 from snapcast.control.protocol import SnapcastProtocol
 
 
+# Several tests below intentionally reach into protected attributes
+# (`_buffer`, `_transport`, `_next_request_id`) to verify internal invariants
+# that are not observable through the public API. This is a deliberate
+# whitebox approach: the protocol's correctness contracts (no orphan KeyError,
+# unique ids under contention, buffer cleanup on cancel) only manifest in
+# internal state. Treat these accesses as test-only coupling, not as a hint
+# that the attributes should be promoted to the public surface.
+
+
 class FakeTransport:
     """Captures bytes written to the transport for inspection."""
 

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -130,5 +130,18 @@ class TestRequestIdThreadSafety(unittest.TestCase):
         )
 
 
+class TestMalformedResponse(unittest.TestCase):
+    """Bug A: handle_response must tolerate JSON-RPC responses without an id field."""
+
+    def test_response_with_missing_id_field_no_crash(self):
+        proto = make_protocol()
+        # No id key at all -> .get('id') returns None -> _buffer.get(None) is None -> early return
+        proto.handle_response({"result": {"foo": "bar"}})
+        # Empty result key, no id -> still no crash
+        proto.handle_response({})
+        # The protocol stays usable
+        self.assertEqual(proto._buffer, {})
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -1,0 +1,58 @@
+"""Tests for snapcast.control.protocol.SnapcastProtocol.
+
+These tests cover the JSON-RPC ID allocation, response dispatch,
+cancellation cleanup, and thread-safety contract.
+"""
+import asyncio
+import json
+import unittest
+from unittest.mock import MagicMock
+
+from snapcast.control.protocol import SnapcastProtocol
+
+
+class FakeTransport:
+    """Captures bytes written to the transport for inspection."""
+
+    def __init__(self):
+        self.written: list[bytes] = []
+        self._closing = False
+
+    def write(self, data):
+        self.written.append(data)
+
+    def is_closing(self):
+        return self._closing
+
+    def close(self):
+        self._closing = True
+
+
+def make_protocol() -> SnapcastProtocol:
+    """Build a SnapcastProtocol wired to a FakeTransport."""
+    callbacks = {
+        "Server.OnDisconnect": MagicMock(),
+    }
+    proto = SnapcastProtocol(callbacks)
+    proto.connection_made(FakeTransport())
+    return proto
+
+
+def written_request(proto: SnapcastProtocol, idx: int = -1) -> dict:
+    """Decode the JSON-RPC payload from the Nth write on the transport."""
+    raw = proto._transport.written[idx]
+    text = raw.decode().rstrip("\r\n")
+    return json.loads(text)
+
+
+class TestProtocolBaseline(unittest.TestCase):
+    """Smoke test that the test file is wired up correctly."""
+
+    def test_make_protocol_constructs(self):
+        proto = make_protocol()
+        self.assertIsNotNone(proto._transport)
+        self.assertEqual(proto._buffer, {})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -3,6 +3,8 @@
 These tests cover the JSON-RPC ID allocation, response dispatch,
 cancellation cleanup, and thread-safety contract.
 """
+from __future__ import annotations
+
 import asyncio
 import json
 import threading

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -54,5 +54,18 @@ class TestProtocolBaseline(unittest.TestCase):
         self.assertEqual(proto._buffer, {})
 
 
+class TestHandleResponse(unittest.TestCase):
+    """Bug A: handle_response must not raise for unknown/orphan request ids."""
+
+    def test_handle_response_for_unknown_id_does_not_raise(self):
+        proto = make_protocol()
+        # No request was made, so buffer is empty
+        self.assertEqual(proto._buffer, {})
+        # Server sends a response with an id we don't know about
+        proto.handle_response({"id": 999, "result": {"server": {}}})
+        # Should be a no-op, not a KeyError
+        self.assertEqual(proto._buffer, {})
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -5,6 +5,7 @@ cancellation cleanup, and thread-safety contract.
 """
 import asyncio
 import json
+import threading
 import unittest
 from unittest.mock import MagicMock
 
@@ -87,6 +88,46 @@ class TestRequestCancellation(unittest.TestCase):
             self.assertEqual(proto._buffer, {})
 
         asyncio.run(run())
+
+
+class TestRequestIdThreadSafety(unittest.TestCase):
+    """Bug A: request id allocation must be unique under concurrent multi-thread access.
+
+    Why this test exists: SnapcastProtocol is currently used from a single asyncio
+    thread, but the public API doesn't forbid asyncio.run_coroutine_threadsafe
+    from multiple threads, and a future refactor may legitimately need cross-thread
+    id allocation. If anyone switches the implementation to a non-thread-safe
+    primitive (itertools.count without GIL guarantees, or naive `+= 1`), this test
+    exposes it under contention. The test stays valid even under PEP 703
+    free-threaded builds where GIL-based atomicity assumptions silently fail.
+    """
+
+    def test_request_id_thread_safety_under_high_concurrency(self):
+        proto = make_protocol()
+        num_threads = 32
+        ids_per_thread = 1000
+        all_ids: list[int] = []
+        collect_lock = threading.Lock()
+
+        def worker():
+            local = [proto._next_request_id() for _ in range(ids_per_thread)]
+            with collect_lock:
+                all_ids.extend(local)
+
+        threads = [threading.Thread(target=worker) for _ in range(num_threads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        expected = num_threads * ids_per_thread
+        self.assertEqual(len(all_ids), expected)
+        self.assertEqual(
+            len(set(all_ids)),
+            expected,
+            f"Duplicate ids detected under thread contention: "
+            f"{expected - len(set(all_ids))} collisions",
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -67,5 +67,27 @@ class TestHandleResponse(unittest.TestCase):
         self.assertEqual(proto._buffer, {})
 
 
+class TestRequestCancellation(unittest.TestCase):
+    """Bug A: cancelling an in-flight request() must always clean its buffer entry."""
+
+    def test_request_cancellation_cleans_buffer(self):
+        async def run():
+            proto = make_protocol()
+            task = asyncio.create_task(proto.request("Server.GetStatus", {}))
+            # Yield control so request() runs up to flag.wait()
+            await asyncio.sleep(0)
+            # Buffer should now hold one pending entry
+            self.assertEqual(len(proto._buffer), 1)
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+            # After cancellation the buffer must be empty again
+            self.assertEqual(proto._buffer, {})
+
+        asyncio.run(run())
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -143,5 +143,34 @@ class TestMalformedResponse(unittest.TestCase):
         self.assertEqual(proto._buffer, {})
 
 
+class TestConcurrentAsyncRequests(unittest.TestCase):
+    """Bug A: multiple concurrent asyncio request() calls must each get a unique id."""
+
+    def test_concurrent_async_requests_get_distinct_ids(self):
+        async def run():
+            proto = make_protocol()
+
+            async def issue():
+                # Start request, but don't wait for the (never-coming) response
+                t = asyncio.create_task(proto.request("Server.GetStatus", {}))
+                await asyncio.sleep(0)
+                return t
+
+            tasks = [await issue() for _ in range(200)]
+            try:
+                ids = []
+                for raw in proto._transport.written:
+                    payload = json.loads(raw.decode().rstrip("\r\n"))
+                    ids.append(payload["id"])
+                self.assertEqual(len(ids), 200)
+                self.assertEqual(len(set(ids)), 200)
+            finally:
+                for t in tasks:
+                    t.cancel()
+                await asyncio.gather(*tasks, return_exceptions=True)
+
+        asyncio.run(run())
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -92,7 +92,7 @@ class TestRequestCancellation(unittest.TestCase):
         asyncio.run(run())
 
 
-class TestRequestIdThreadSafety(unittest.TestCase):
+class TestRequestIdConcurrentUniqueness(unittest.TestCase):
     """Bug A: request id allocation must be unique under concurrent multi-thread access.
 
     Why this test exists: SnapcastProtocol is currently used from a single asyncio
@@ -104,7 +104,13 @@ class TestRequestIdThreadSafety(unittest.TestCase):
     free-threaded builds where GIL-based atomicity assumptions silently fail.
     """
 
-    def test_request_id_thread_safety_under_high_concurrency(self):
+    def test_request_ids_unique_under_concurrent_threads(self):
+        """Asserts the uniqueness invariant of `_next_request_id` when called
+        from many threads. Under standard GIL CPython the lock is
+        correctness-by-inspection (the read-modify-write `i += 1` is
+        non-atomic but rarely tears in practice). Under PEP 703 free-threaded
+        builds the lock is load-bearing - without it, this test would expose
+        tearing."""
         proto = make_protocol()
         num_threads = 32
         ids_per_thread = 1000

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -204,5 +204,58 @@ class TestNoCollisionCorruption(unittest.TestCase):
         asyncio.run(run())
 
 
+class TestExistingBehaviorRegression(unittest.TestCase):
+    """Confirm prior behavior of SnapcastProtocol is preserved by the Bug A fixes."""
+
+    def test_happy_path_response_dispatch(self):
+        async def run():
+            proto = make_protocol()
+            t = asyncio.create_task(proto.request("Server.GetStatus", {}))
+            await asyncio.sleep(0)
+            req_id = json.loads(proto._transport.written[-1].decode().rstrip("\r\n"))["id"]
+            proto.handle_response({"id": req_id, "result": {"server": "ok"}})
+            result, error = await t
+            self.assertEqual(result, {"server": "ok"})
+            self.assertIsNone(error)
+
+        asyncio.run(run())
+
+    def test_connection_lost_signals_all_pending(self):
+        async def run():
+            proto = make_protocol()
+            t1 = asyncio.create_task(proto.request("A", {}))
+            t2 = asyncio.create_task(proto.request("B", {}))
+            await asyncio.sleep(0)
+            self.assertEqual(len(proto._buffer), 2)
+            proto.connection_lost(None)
+            r1, e1 = await t1
+            r2, e2 = await t2
+            self.assertIsNone(r1)
+            self.assertIsNone(r2)
+            self.assertEqual(e1, {"code": -1, "message": "connection lost"})
+            self.assertEqual(e2, {"code": -1, "message": "connection lost"})
+
+        asyncio.run(run())
+
+    def test_data_received_handles_partial_messages(self):
+        proto = make_protocol()
+        # Make a request first so the buffer has an entry to satisfy
+        async def run():
+            t = asyncio.create_task(proto.request("Server.GetStatus", {}))
+            await asyncio.sleep(0)
+            req_id = json.loads(proto._transport.written[-1].decode().rstrip("\r\n"))["id"]
+            full = json.dumps({"id": req_id, "result": {"ok": True}}) + "\r\n"
+            half_a = full[: len(full) // 2].encode()
+            half_b = full[len(full) // 2 :].encode()
+            proto.data_received(half_a)
+            # Buffer is incomplete (no \r\n yet) -> request still pending
+            self.assertEqual(len(proto._buffer), 1)
+            proto.data_received(half_b)
+            result, _ = await t
+            self.assertEqual(result, {"ok": True})
+
+        asyncio.run(run())
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -172,5 +172,37 @@ class TestConcurrentAsyncRequests(unittest.TestCase):
         asyncio.run(run())
 
 
+class TestNoCollisionCorruption(unittest.TestCase):
+    """Bug A end-to-end: each request must get its own response back, never another's."""
+
+    def test_no_collision_corruption_under_load(self):
+        async def run():
+            proto = make_protocol()
+            num = 100
+
+            async def one_request(payload_marker):
+                # Issue the request, then synthesize a matching response
+                t = asyncio.create_task(proto.request("Server.GetStatus", {}))
+                await asyncio.sleep(0)
+                # Look up the id we just allocated
+                last_payload = json.loads(
+                    proto._transport.written[-1].decode().rstrip("\r\n")
+                )
+                req_id = last_payload["id"]
+                # Server replies with our marker as the result
+                proto.handle_response({"id": req_id, "result": {"marker": payload_marker}})
+                result, error = await t
+                return payload_marker, result, error
+
+            answers = await asyncio.gather(
+                *(one_request(i) for i in range(num))
+            )
+            for marker, result, error in answers:
+                self.assertIsNone(error)
+                self.assertEqual(result, {"marker": marker})
+
+        asyncio.run(run())
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Opening this after chasing down a bunch of symptoms downstream in Music
Assistant: occasional `KeyError: 385` / `KeyError: 518` followed by
`Server disconnected: <id>`, also reported in
https://github.com/music-assistant/support/issues/4435 (where a commenter
independently traced it to this library). The trail led back to this
library's JSON-RPC request handling.

## What was broken

Three things compound under concurrent load:

1. Request ids came from `random.randint(1, 1000)`. With ~50 in-flight
   calls the birthday paradox already gives a >70% collision probability.
   When two callers pick the same id, the second one's `_buffer[id] = ...`
   overwrites the first; responses get cross-routed and the original waiter
   hangs forever.

2. When a response arrived for an id no longer in `_buffer` (cancellation,
   late server reply, or the collision case above), `handle_response` did
   `self._buffer[id]` and the `KeyError` propagated out. That surfaced in
   the asyncio transport and disconnected the snapserver session.

3. Cancelled `request()` calls (e.g. via `asyncio.wait_for` timeout) left
   `_buffer[id]` behind, so the dict slowly grew and stale responses had a
   chance to land in it later.

## Fix

A monotonic counter under `threading.Lock` replaces `random.randint`. The
lock is overkill for asyncio under current CPython, but I'd rather have it
than rely on `itertools.count` atomicity, which is implementation-defined
under PEP 703 free-threaded builds.

`handle_response` uses `.get()` and silently drops responses for unknown
ids, with a `DEBUG` log so future regressions stay diagnosable. And
`request()` runs under `try/finally` so `_buffer.pop(id, None)` always runs.


## Testing

I patched the lib into my running Music Assistant container (snapserver
0.35.0 on the other side) and ran 200 concurrent `server.rpc_version()`
calls:

|                         | Before | After |
|---|---|---|
| Successful              | 174 / 200 (87%) | 200 / 200 (100%) |
| Timeouts (10s deadline) | 26 | 0 |
| Wall time               | 10.0s | 0.1s |

Same script, same snapserver, only `protocol.py` differs. The 26 timeouts
match the ~19 collision pairs the birthday paradox predicts for
`randint(1,1000)` at that load.

